### PR TITLE
[TH2-1163] Removed batch limit by message number; Implemented CradleObjectsFactory to create batches of size conforming to CradleStorage settings.

### DIFF
--- a/cradle-cassandra/build.gradle
+++ b/cradle-cassandra/build.gradle
@@ -10,6 +10,12 @@ dependencies {
 	compile "com.datastax.oss:java-driver-mapper-runtime:${driver_version}"
 	
 	annotationProcessor "com.datastax.oss:java-driver-mapper-processor:${driver_version}"
+	
+	testCompile 'org.testng:testng:7.1.0'
+}
+
+test {
+	useTestNG()
 }
 
 jar {

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraCradleStorage.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraCradleStorage.java
@@ -118,7 +118,7 @@ public class CassandraCradleStorage extends CradleStorage
 		this.connection = connection;
 		this.settings = settings;
 		this.semaphore = new CassandraSemaphore(connection.getSettings().getMaxParallelQueries());
-		this.objectsFactory = new CradleObjectsFactory(settings.getMaxMessageBatchSize());
+		this.objectsFactory = new CradleObjectsFactory(settings.getMaxMessageBatchSize(), settings.getMaxTestEventBatchSize());
 	}
 	
 	

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraCradleStorage.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraCradleStorage.java
@@ -25,6 +25,7 @@ import com.datastax.oss.driver.api.core.type.reflect.GenericType;
 import com.datastax.oss.driver.api.querybuilder.insert.Insert;
 import com.datastax.oss.driver.api.querybuilder.insert.RegularInsert;
 import com.datastax.oss.driver.api.querybuilder.select.Select;
+import com.exactpro.cradle.CradleObjectsFactory;
 import com.exactpro.cradle.CradleStorage;
 import com.exactpro.cradle.Direction;
 import com.exactpro.cradle.TimeRelation;
@@ -100,6 +101,7 @@ public class CassandraCradleStorage extends CradleStorage
 	private final CassandraConnection connection;
 	private final CassandraStorageSettings settings;
 	private final CassandraSemaphore semaphore;
+	private final CradleObjectsFactory objectsFactory;
 	
 	private UUID instanceUuid;
 	private CassandraDataMapper dataMapper;
@@ -116,6 +118,7 @@ public class CassandraCradleStorage extends CradleStorage
 		this.connection = connection;
 		this.settings = settings;
 		this.semaphore = new CassandraSemaphore(connection.getSettings().getMaxParallelQueries());
+		this.objectsFactory = new CradleObjectsFactory(settings.getMaxMessageBatchSize());
 	}
 	
 	
@@ -592,6 +595,12 @@ public class CassandraCradleStorage extends CradleStorage
 		for (TestEventChildDateEntity entity : getTestEventChildrenDatesOperator().get(instanceUuid, parentId.toString(), readAttrs))
 			result.add(entity.getStartDate().atStartOfDay(TIMEZONE_OFFSET).toInstant());
 		return result;
+	}
+	
+	@Override
+	public CradleObjectsFactory getObjectsFactory()
+	{
+		return objectsFactory;
 	}
 	
 	

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraStorageSettings.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraStorageSettings.java
@@ -18,6 +18,7 @@ package com.exactpro.cradle.cassandra;
 
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.exactpro.cradle.cassandra.connection.NetworkTopologyStrategy;
+import com.exactpro.cradle.messages.StoredMessageBatch;
 
 public class CassandraStorageSettings
 {
@@ -35,7 +36,8 @@ public class CassandraStorageSettings
 			TEST_EVENTS_CHILDREN_DATES_TABLE_DEFAULT_NAME = "test_events_children_dates",
 			TEST_EVENTS_MESSAGES_TABLE_DEFAULT_NAME = "test_events_messages",
 			MESSAGES_TEST_EVENTS_TABLE_DEFAULT_NAME = "messages_test_events";
-	public static final long DEFAULT_TIMEOUT = 5000;
+	public static final long DEFAULT_TIMEOUT = 5000,
+			DEFAULT_MAX_MESSAGE_BATCH_SIZE = StoredMessageBatch.DEFAULT_MAX_BATCH_SIZE;
 	public static final ConsistencyLevel DEFAULT_CONSISTENCY_LEVEL = ConsistencyLevel.LOCAL_QUORUM;
 	public static final int DEFAULT_KEYSPACE_REPL_FACTOR = 1;
 	public static final int BATCH_MESSAGES_LIMIT = 10,
@@ -57,6 +59,7 @@ public class CassandraStorageSettings
 	private ConsistencyLevel writeConsistencyLevel,
 			readConsistencyLevel;
 	private int keyspaceReplicationFactor;
+	private long maxMessageBatchSize;
 	
 	public CassandraStorageSettings(String keyspace, NetworkTopologyStrategy networkTopologyStrategy, 
 			long timeout, ConsistencyLevel writeConsistencyLevel, ConsistencyLevel readConsistencyLevel)
@@ -77,6 +80,7 @@ public class CassandraStorageSettings
 		this.writeConsistencyLevel = writeConsistencyLevel;
 		this.readConsistencyLevel = readConsistencyLevel;
 		this.keyspaceReplicationFactor = DEFAULT_KEYSPACE_REPL_FACTOR;
+		this.maxMessageBatchSize = DEFAULT_MAX_MESSAGE_BATCH_SIZE;
 	}
 
 	public CassandraStorageSettings(String keyspace, NetworkTopologyStrategy networkTopology)
@@ -256,5 +260,16 @@ public class CassandraStorageSettings
 	public void setReadConsistencyLevel(ConsistencyLevel readConsistencyLevel)
 	{
 		this.readConsistencyLevel = readConsistencyLevel;
+	}
+	
+	
+	public long getMaxMessageBatchSize()
+	{
+		return maxMessageBatchSize;
+	}
+	
+	public void setMaxMessageBatchSize(long maxMessageBatchSize)
+	{
+		this.maxMessageBatchSize = maxMessageBatchSize;
 	}
 }

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraStorageSettings.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraStorageSettings.java
@@ -19,6 +19,7 @@ package com.exactpro.cradle.cassandra;
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.exactpro.cradle.cassandra.connection.NetworkTopologyStrategy;
 import com.exactpro.cradle.messages.StoredMessageBatch;
+import com.exactpro.cradle.testevents.StoredTestEventBatch;
 
 public class CassandraStorageSettings
 {
@@ -37,7 +38,8 @@ public class CassandraStorageSettings
 			TEST_EVENTS_MESSAGES_TABLE_DEFAULT_NAME = "test_events_messages",
 			MESSAGES_TEST_EVENTS_TABLE_DEFAULT_NAME = "messages_test_events";
 	public static final long DEFAULT_TIMEOUT = 5000,
-			DEFAULT_MAX_MESSAGE_BATCH_SIZE = StoredMessageBatch.DEFAULT_MAX_BATCH_SIZE;
+			DEFAULT_MAX_MESSAGE_BATCH_SIZE = StoredMessageBatch.DEFAULT_MAX_BATCH_SIZE,
+			DEFAULT_MAX_EVENT_BATCH_SIZE = StoredTestEventBatch.DEFAULT_MAX_BATCH_SIZE;
 	public static final ConsistencyLevel DEFAULT_CONSISTENCY_LEVEL = ConsistencyLevel.LOCAL_QUORUM;
 	public static final int DEFAULT_KEYSPACE_REPL_FACTOR = 1;
 	public static final int BATCH_MESSAGES_LIMIT = 10,
@@ -59,7 +61,8 @@ public class CassandraStorageSettings
 	private ConsistencyLevel writeConsistencyLevel,
 			readConsistencyLevel;
 	private int keyspaceReplicationFactor;
-	private long maxMessageBatchSize;
+	private long maxMessageBatchSize,
+			maxTestEventBatchSize;
 	
 	public CassandraStorageSettings(String keyspace, NetworkTopologyStrategy networkTopologyStrategy, 
 			long timeout, ConsistencyLevel writeConsistencyLevel, ConsistencyLevel readConsistencyLevel)
@@ -81,6 +84,7 @@ public class CassandraStorageSettings
 		this.readConsistencyLevel = readConsistencyLevel;
 		this.keyspaceReplicationFactor = DEFAULT_KEYSPACE_REPL_FACTOR;
 		this.maxMessageBatchSize = DEFAULT_MAX_MESSAGE_BATCH_SIZE;
+		this.maxTestEventBatchSize = DEFAULT_MAX_EVENT_BATCH_SIZE;
 	}
 
 	public CassandraStorageSettings(String keyspace, NetworkTopologyStrategy networkTopology)
@@ -271,5 +275,16 @@ public class CassandraStorageSettings
 	public void setMaxMessageBatchSize(long maxMessageBatchSize)
 	{
 		this.maxMessageBatchSize = maxMessageBatchSize;
+	}
+	
+	
+	public long getMaxTestEventBatchSize()
+	{
+		return maxTestEventBatchSize;
+	}
+	
+	public void setMaxTestEventBatchSize(long maxTestEventBatchSize)
+	{
+		this.maxTestEventBatchSize = maxTestEventBatchSize;
 	}
 }

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/dao/messages/MessageBatchOperator.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/dao/messages/MessageBatchOperator.java
@@ -16,7 +16,6 @@
 
 package com.exactpro.cradle.cassandra.dao.messages;
 
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -31,7 +30,6 @@ import com.datastax.oss.driver.api.mapper.annotations.QueryProvider;
 import com.datastax.oss.driver.api.mapper.annotations.Select;
 import com.exactpro.cradle.cassandra.CassandraSemaphore;
 import com.exactpro.cradle.messages.StoredMessageFilter;
-import com.exactpro.cradle.utils.CradleStorageException;
 
 import static com.exactpro.cradle.cassandra.StorageConstants.*;
 
@@ -55,11 +53,17 @@ public interface MessageBatchOperator
 			+MESSAGE_INDEX+">=:fromIndex AND "+MESSAGE_INDEX+"<=:toIndex")
 	CompletableFuture<MappedAsyncPagingIterable<DetailedMessageBatchEntity>> getMessageBatches(UUID instanceId, String streamName, String direction, 
 			long fromIndex, long toIndex, Function<BoundStatementBuilder, BoundStatementBuilder> attributes);
-	
+
 	@Query("SELECT * FROM ${qualifiedTableId} WHERE "
 			+INSTANCE_ID+"=:instanceId AND "+STREAM_NAME+"=:streamName AND "+DIRECTION+"=:direction AND "
 			+MESSAGE_INDEX+"<=:toIndex ORDER BY "+DIRECTION+" DESC, "+MESSAGE_INDEX+" DESC")
 	PagingIterable<DetailedMessageBatchEntity> getMessageBatchesReversed(UUID instanceId, String streamName, String direction, long toIndex, 
+			Function<BoundStatementBuilder, BoundStatementBuilder> attributes);
+	
+	@Query("SELECT * FROM ${qualifiedTableId} WHERE "
+			+INSTANCE_ID+"=:instanceId AND "+STREAM_NAME+"=:streamName AND "+DIRECTION+"=:direction AND "
+			+MESSAGE_INDEX+"<=:messageIndex ORDER BY "+DIRECTION+" DESC, "+MESSAGE_INDEX+" DESC LIMIT 1")
+	CompletableFuture<DetailedMessageBatchEntity> getMessageBatch(UUID instanceId, String streamName, String direction, long messageIndex, 
 			Function<BoundStatementBuilder, BoundStatementBuilder> attributes);
 	
 	@Select

--- a/cradle-cassandra/src/test/java/com/exactpro/cradle/cassandra/CassasndraObjectsFactoryTest.java
+++ b/cradle-cassandra/src/test/java/com/exactpro/cradle/cassandra/CassasndraObjectsFactoryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020-2020 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.cradle.cassandra;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.exactpro.cradle.CradleStorage;
+import com.exactpro.cradle.Direction;
+import com.exactpro.cradle.cassandra.connection.CassandraConnection;
+import com.exactpro.cradle.messages.StoredMessageBatch;
+import com.exactpro.cradle.messages.StoredMessageBatchId;
+import com.exactpro.cradle.messages.StoredMessageId;
+import com.exactpro.cradle.testevents.StoredTestEventBatch;
+import com.exactpro.cradle.testevents.StoredTestEventId;
+import com.exactpro.cradle.testevents.TestEventBatchToStore;
+import com.exactpro.cradle.utils.CradleIdException;
+import com.exactpro.cradle.utils.CradleStorageException;
+
+import static com.exactpro.cradle.messages.StoredMessageBatchId.*;
+
+public class CassasndraObjectsFactoryTest
+{
+	private final long maxMessageBatchSize = 999,
+			maxEventBatchSize = 888;
+	private CradleStorage storage;
+	
+	@BeforeClass
+	public void prepare()
+	{
+		CassandraStorageSettings settings = new CassandraStorageSettings();
+		settings.setMaxMessageBatchSize(maxMessageBatchSize);
+		settings.setMaxTestEventBatchSize(maxEventBatchSize);
+		storage = new CassandraCradleStorage(new CassandraConnection(), settings);
+	}
+	
+	@Test
+	public void createMessageBatch()
+	{
+		StoredMessageBatch batch = storage.getObjectsFactory().createMessageBatch();
+		Assert.assertEquals(batch.getSpaceLeft(), maxMessageBatchSize, 
+				"CradleObjectsFactory of CassandraCradleStorage creates StoredMessageBatch with maximum size defined in storage settings");
+	}
+	
+	@Test
+	public void createTestEventBatch() throws CradleStorageException
+	{
+		StoredTestEventBatch batch = storage.getObjectsFactory().createTestEventBatch(TestEventBatchToStore.builder()
+				.id(new StoredTestEventId("test_event1"))
+				.name("test_event")
+				.parentId(new StoredTestEventId("parent_event1"))
+				.build());
+		Assert.assertEquals(batch.getSpaceLeft(), maxEventBatchSize, 
+				"CradleObjectsFactory of CassandraCradleStorage creates StoredTestEventBatch with maximum size defined in storage settings");
+	}
+}

--- a/cradle-core/src/main/java/com/exactpro/cradle/CradleObjectsFactory.java
+++ b/cradle-core/src/main/java/com/exactpro/cradle/CradleObjectsFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020-2020 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.cradle;
+
+import com.exactpro.cradle.messages.StoredMessageBatch;
+import com.exactpro.cradle.testevents.TestEventBatchToStore;
+import com.exactpro.cradle.testevents.TestEventBatchToStoreBuilder;
+import com.exactpro.cradle.testevents.TestEventToStore;
+import com.exactpro.cradle.testevents.TestEventToStoreBuilder;
+
+/**
+ * Factory to create objects to be used with {@link CradleStorage}. Created objects will conform with particular CradleStorage settings.
+ */
+public class CradleObjectsFactory
+{
+	private final long maxMessageBatchSize;
+	
+	/**
+	 * Creates new factory for objects to be used with {@link CradleStorage}
+	 * @param maxMessageBatchSize maximum size of messages (in bytes) that {@link StoredMessageBatch} can hold
+	 */
+	public CradleObjectsFactory(long maxMessageBatchSize)
+	{
+		this.maxMessageBatchSize = maxMessageBatchSize;
+	}
+	
+	
+	public StoredMessageBatch createMessageBatch()
+	{
+		return new StoredMessageBatch(maxMessageBatchSize);
+	}
+	
+	
+	public TestEventToStore createTestEvent()
+	{
+		return new TestEventToStore();
+	}
+	
+	public TestEventToStoreBuilder createTestEventBuilder()
+	{
+		return new TestEventToStoreBuilder();
+	}
+	
+	
+	public TestEventBatchToStore createTestEventBatch()
+	{
+		return new TestEventBatchToStore();
+	}
+	
+	public TestEventBatchToStoreBuilder createTestEventBatchBuilder()
+	{
+		return new TestEventBatchToStoreBuilder();
+	}
+}

--- a/cradle-core/src/main/java/com/exactpro/cradle/CradleObjectsFactory.java
+++ b/cradle-core/src/main/java/com/exactpro/cradle/CradleObjectsFactory.java
@@ -17,25 +17,32 @@
 package com.exactpro.cradle;
 
 import com.exactpro.cradle.messages.StoredMessageBatch;
+import com.exactpro.cradle.testevents.StoredTestEventBatch;
+import com.exactpro.cradle.testevents.StoredTestEventSingle;
+import com.exactpro.cradle.testevents.StoredTestEventWithContent;
 import com.exactpro.cradle.testevents.TestEventBatchToStore;
 import com.exactpro.cradle.testevents.TestEventBatchToStoreBuilder;
 import com.exactpro.cradle.testevents.TestEventToStore;
 import com.exactpro.cradle.testevents.TestEventToStoreBuilder;
+import com.exactpro.cradle.utils.CradleStorageException;
 
 /**
  * Factory to create objects to be used with {@link CradleStorage}. Created objects will conform with particular CradleStorage settings.
  */
 public class CradleObjectsFactory
 {
-	private final long maxMessageBatchSize;
+	private final long maxMessageBatchSize,
+			maxTestEventBatchSize;
 	
 	/**
 	 * Creates new factory for objects to be used with {@link CradleStorage}
 	 * @param maxMessageBatchSize maximum size of messages (in bytes) that {@link StoredMessageBatch} can hold
+	 * @param maxTestEventBatchSize maximum size of test events (in bytes) that {@link StoredTestEventBatch} can hold
 	 */
-	public CradleObjectsFactory(long maxMessageBatchSize)
+	public CradleObjectsFactory(long maxMessageBatchSize, long maxTestEventBatchSize)
 	{
 		this.maxMessageBatchSize = maxMessageBatchSize;
+		this.maxTestEventBatchSize = maxTestEventBatchSize;
 	}
 	
 	
@@ -44,25 +51,13 @@ public class CradleObjectsFactory
 		return new StoredMessageBatch(maxMessageBatchSize);
 	}
 	
-	
-	public TestEventToStore createTestEvent()
+	public StoredTestEventSingle createTestEvent(StoredTestEventWithContent eventData) throws CradleStorageException
 	{
-		return new TestEventToStore();
+		return new StoredTestEventSingle(eventData);
 	}
 	
-	public TestEventToStoreBuilder createTestEventBuilder()
+	public StoredTestEventBatch createTestEventBatch(TestEventBatchToStore batchData) throws CradleStorageException
 	{
-		return new TestEventToStoreBuilder();
-	}
-	
-	
-	public TestEventBatchToStore createTestEventBatch()
-	{
-		return new TestEventBatchToStore();
-	}
-	
-	public TestEventBatchToStoreBuilder createTestEventBatchBuilder()
-	{
-		return new TestEventBatchToStoreBuilder();
+		return new StoredTestEventBatch(batchData, maxTestEventBatchSize);
 	}
 }

--- a/cradle-core/src/main/java/com/exactpro/cradle/CradleStorage.java
+++ b/cradle-core/src/main/java/com/exactpro/cradle/CradleStorage.java
@@ -85,6 +85,8 @@ public abstract class CradleStorage
 	protected abstract Collection<Instant> doGetRootTestEventsDates() throws IOException;
 	protected abstract Collection<Instant> doGetTestEventsDates(StoredTestEventId parentId) throws IOException;
 	
+	public abstract CradleObjectsFactory getObjectsFactory();
+	
 	
 	/**
 	 * TestEventsMessagesLinker is used to obtain links between test events and messages

--- a/cradle-core/src/main/java/com/exactpro/cradle/utils/MessageUtils.java
+++ b/cradle-core/src/main/java/com/exactpro/cradle/utils/MessageUtils.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.zip.DataFormatException;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.SerializationUtils;
 
 import com.exactpro.cradle.messages.MessageToStore;
@@ -48,6 +49,8 @@ public class MessageUtils
 			throw new CradleStorageException("Message must have direction");
 		if (message.getTimestamp() == null)
 			throw new CradleStorageException("Message must have timestamp");
+		if (ArrayUtils.isEmpty(message.getContent()))
+			throw new CradleStorageException("Message must have content");
 	}
 	
 	/**

--- a/cradle-core/src/test/java/com/exactpro/cradle/CradleObjectsFactoryTest.java
+++ b/cradle-core/src/test/java/com/exactpro/cradle/CradleObjectsFactoryTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020-2020 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.cradle;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.exactpro.cradle.messages.StoredMessageBatch;
+import com.exactpro.cradle.testevents.StoredTestEventBatch;
+import com.exactpro.cradle.testevents.StoredTestEventId;
+import com.exactpro.cradle.testevents.TestEventBatchToStore;
+import com.exactpro.cradle.utils.CradleStorageException;
+
+public class CradleObjectsFactoryTest
+{
+	private final long maxMessageBatchSize = 123,
+			maxEventBatchSize = 234;
+	private CradleObjectsFactory factory;
+	
+	@BeforeClass
+	public void prepare()
+	{
+		factory = new CradleObjectsFactory(maxMessageBatchSize, maxEventBatchSize);
+	}
+	
+	@Test
+	public void createMessageBatch()
+	{
+		StoredMessageBatch batch = factory.createMessageBatch();
+		Assert.assertEquals(batch.getSpaceLeft(), maxMessageBatchSize, 
+				"CradleObjectsFactory creates StoredMessageBatch with maximum size defined in factory constructor");
+	}
+	
+	@Test
+	public void createTestEventBatch() throws CradleStorageException
+	{
+		StoredTestEventBatch batch = factory.createTestEventBatch(TestEventBatchToStore.builder().id(new StoredTestEventId("test_event1"))
+				.name("test_event")
+				.parentId(new StoredTestEventId("parent_event1"))
+				.build());
+		Assert.assertEquals(batch.getSpaceLeft(), maxEventBatchSize, 
+				"CradleObjectsFactory creates StoredTestEventBatch with maximum size defined in factory constructor");
+	}
+}

--- a/cradle-core/src/test/java/com/exactpro/cradle/messages/StoredMessageBatchJoinTest.java
+++ b/cradle-core/src/test/java/com/exactpro/cradle/messages/StoredMessageBatchJoinTest.java
@@ -16,8 +16,7 @@
 
 package com.exactpro.cradle.messages;
 
-import static com.exactpro.cradle.messages.StoredMessageBatch.MAX_MESSAGES_COUNT;
-import static com.exactpro.cradle.messages.StoredMessageBatch.MAX_MESSAGES_SIZE;
+import static com.exactpro.cradle.messages.StoredMessageBatch.DEFAULT_MAX_BATCH_SIZE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -39,7 +38,7 @@ public class StoredMessageBatchJoinTest {
         assertTrue(emptyBatch.addBatch(batch));
 
         assertEquals(emptyBatch.getMessageCount(), 5);
-        assertEquals(emptyBatch.getMessagesSize(), 25);
+        assertEquals(emptyBatch.getBatchSize(), 25);
         assertEquals(emptyBatch.getStreamName(), "test");
         assertEquals(emptyBatch.getDirection(), Direction.FIRST);
     }
@@ -57,32 +56,28 @@ public class StoredMessageBatchJoinTest {
     @DataProvider(name = "full batches")
     public Object[][] fullBatches() throws CradleStorageException {
         return new Object[][] {
-                { createFullByCountBatch("test", 0, Direction.FIRST) },
                 { createFullBySizeBatch("test", 0, Direction.FIRST) }
         };
     }
 
     @Test(dataProvider = "full batches")
     public void testJoinFullBatchWithEmpty(StoredMessageBatch batch) throws CradleStorageException {
-        long messagesSize = batch.getMessagesSize();
+        long messagesSize = batch.getBatchSize();
         int messageCount = batch.getMessageCount();
         StoredMessageBatchId id = batch.getId();
 
         assertTrue(batch.addBatch(createEmptyBatch()));
 
         assertEquals(batch.getMessageCount(), messageCount);
-        assertEquals(batch.getMessagesSize(), messagesSize);
+        assertEquals(batch.getBatchSize(), messagesSize);
         assertEquals(batch.getId(), id);
     }
 
     @DataProvider(name = "full batches matrix")
     public Object[][] fullBatchesMatrix() throws CradleStorageException {
-        StoredMessageBatch fullByCountBatch = createFullByCountBatch("test", 0, Direction.FIRST);
         StoredMessageBatch fullBySizeBatch = createFullBySizeBatch("test", 0, Direction.FIRST);
         return new Object[][] {
-                { fullByCountBatch, fullByCountBatch },
-                { fullBySizeBatch, fullBySizeBatch },
-                { fullByCountBatch, fullBySizeBatch }
+                { fullBySizeBatch, fullBySizeBatch }
         };
     }
 
@@ -98,31 +93,19 @@ public class StoredMessageBatchJoinTest {
 
         assertTrue(first.addBatch(second));
         assertEquals(first.getMessageCount(), 10);
-        assertEquals(first.getMessagesSize(), 50);
-        assertEquals(first.getStreamName(), "test");
-        assertEquals(first.getDirection(), Direction.FIRST);
-    }
-
-    @Test
-    public void testAddBatchMoreThanLimitByCount() throws CradleStorageException {
-        StoredMessageBatch first = createBatch("test", 0, Direction.FIRST, MAX_MESSAGES_COUNT - 1, 0);
-        StoredMessageBatch second = createBatch("test", 5, Direction.FIRST, MAX_MESSAGES_COUNT - 1, 0);
-
-        assertFalse(first.addBatch(second));
-        assertEquals(first.getMessageCount(), MAX_MESSAGES_COUNT - 1);
-        assertEquals(first.getMessagesSize(), 0);
+        assertEquals(first.getBatchSize(), 50);
         assertEquals(first.getStreamName(), "test");
         assertEquals(first.getDirection(), Direction.FIRST);
     }
 
     @Test
     public void testAddBatchMoreThanLimitBySize() throws CradleStorageException {
-        StoredMessageBatch first = createBatch("test", 0, Direction.FIRST, 1, MAX_MESSAGES_SIZE - 1);
-        StoredMessageBatch second = createBatch("test", 5, Direction.FIRST, 1, MAX_MESSAGES_SIZE - 1);
+        StoredMessageBatch first = createBatch("test", 0, Direction.FIRST, 1, DEFAULT_MAX_BATCH_SIZE - 1);
+        StoredMessageBatch second = createBatch("test", 5, Direction.FIRST, 1, DEFAULT_MAX_BATCH_SIZE - 1);
 
         assertFalse(first.addBatch(second));
         assertEquals(first.getMessageCount(), 1);
-        assertEquals(first.getMessagesSize(), MAX_MESSAGES_SIZE - 1);
+        assertEquals(first.getBatchSize(), DEFAULT_MAX_BATCH_SIZE - 1);
         assertEquals(first.getStreamName(), "test");
         assertEquals(first.getDirection(), Direction.FIRST);
     }
@@ -181,11 +164,7 @@ public class StoredMessageBatchJoinTest {
         return new StoredMessageBatch();
     }
 
-    private StoredMessageBatch createFullByCountBatch(String streamName, long startIndex, Direction direction) throws CradleStorageException {
-        return createBatch(streamName, startIndex, direction, MAX_MESSAGES_COUNT, 0);
-    }
-
     private StoredMessageBatch createFullBySizeBatch(String streamName, long startIndex, Direction direction) throws CradleStorageException {
-        return createBatch(streamName, startIndex, direction, 1, MAX_MESSAGES_SIZE);
+        return createBatch(streamName, startIndex, direction, 1, DEFAULT_MAX_BATCH_SIZE);
     }
 }

--- a/cradle-core/src/test/java/com/exactpro/cradle/utils/MessageUtilsTest.java
+++ b/cradle-core/src/test/java/com/exactpro/cradle/utils/MessageUtilsTest.java
@@ -45,6 +45,7 @@ public class MessageUtilsTest
 		String streamName = "Stream1";
 		Direction direction = Direction.FIRST;
 		Instant timestamp = Instant.now();
+		byte[] content = "Message text".getBytes();
 		
 		long index = 10;
 		batch = new StoredMessageBatch();
@@ -53,6 +54,7 @@ public class MessageUtilsTest
 				.direction(direction)
 				.index(10)
 				.timestamp(timestamp)
+				.content(content)
 				.build());
 		
 		msg2 = batch.addMessage(builder
@@ -60,6 +62,7 @@ public class MessageUtilsTest
 				.direction(direction)
 				.index(index+10)  //Need to have a gap between indices to verify that messages are written/read correctly
 				.timestamp(timestamp)
+				.content(content)
 				.build());
 	}
 	

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-release_version = 2.5.0
+release_version = 2.6.0
 
 bintray_user=
 bintray_key=


### PR DESCRIPTION
Example of use:
```java
CassandraConnection con = new CassandraConnection();
CassandraStorageSettings storageSettings = new CassandraStorageSettings(keyspace);
storageSettings.setMaxMessageBatchSize(4*1024*1024);  //4 Mb message batch limit

CradleStorage storage = new CassandraCradleStorage(con, storageSettings);

CradleObjectsFactory factory = storage.getObjectsFactory();
StoredMessageBatch batch = factory.createMessageBatch();
```