### PR TITLE
TH2-1721. Implemented compression of batch events metadata after serialization

### DIFF
--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/dao/testevents/TestEventWithParentMetadataEntity.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/dao/testevents/TestEventWithParentMetadataEntity.java
@@ -25,7 +25,6 @@ import java.util.UUID;
 import com.datastax.oss.driver.api.mapper.annotations.CqlName;
 import com.exactpro.cradle.testevents.StoredTestEvent;
 import com.exactpro.cradle.testevents.StoredTestEventBatch;
-import com.exactpro.cradle.testevents.StoredTestEventBatchMetadata;
 import com.exactpro.cradle.testevents.StoredTestEventId;
 import com.exactpro.cradle.testevents.StoredTestEventMetadata;
 import com.exactpro.cradle.utils.TestEventUtils;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-release_version = 2.8.0
+release_version = 2.9.0
 
 bintray_user=
 bintray_key=


### PR DESCRIPTION
Metadata is decompressed before deserialization. If decompression fails, deserialization is made on given bytes, meaning that metadata wa written by old Cradle API.