### PR TITLE
TH2-3122. Table messages_timestamps is used instead time_messages.

### DIFF
--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraStorageSettings.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraStorageSettings.java
@@ -29,7 +29,7 @@ public class CassandraStorageSettings
 			INSTANCES_TABLE_DEFAULT_NAME = "instances",
 			MESSAGES_TABLE_DEFAULT_NAME = "messages",
 			PROCESSED_MESSAGES_TABLE_DEFAULT_NAME = "processed_messages",
-			TIME_MESSAGES_TABLE_DEFAULT_NAME = "time_messages",
+			TIME_MESSAGES_TABLE_DEFAULT_NAME = "messages_timestamps",
 			TEST_EVENTS_TABLE_DEFAULT_NAME = "test_events",
 			TIME_TEST_EVENTS_TABLE_DEFAULT_NAME = "time_test_events",
 			ROOT_TEST_EVENTS_TABLE_DEFAULT_NAME = "root_test_events",

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/TablesCreator.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/TablesCreator.java
@@ -115,9 +115,10 @@ public class TablesCreator
 				.withPartitionKey(INSTANCE_ID, DataTypes.UUID)
 				.withPartitionKey(STREAM_NAME, DataTypes.TEXT)
 				.withPartitionKey(DIRECTION, DataTypes.TEXT)
-				.withPartitionKey(MESSAGE_DATE, DataTypes.DATE)
+				.withClusteringColumn(MESSAGE_DATE, DataTypes.DATE)
 				.withClusteringColumn(MESSAGE_TIME, DataTypes.TIME)
 				.withClusteringColumn(MESSAGE_INDEX, DataTypes.BIGINT)
+				.withClusteringOrder(MESSAGE_DATE, ClusteringOrder.ASC)
 				.withClusteringOrder(MESSAGE_TIME, ClusteringOrder.ASC)
 				.withClusteringOrder(MESSAGE_INDEX, ClusteringOrder.ASC);
 		

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/dao/messages/MessageBatchQueryProvider.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/dao/messages/MessageBatchQueryProvider.java
@@ -157,7 +157,7 @@ public class MessageBatchQueryProvider
 		if (!isLeftIndexSelected && filter.getTimestampFrom() != null)
 			select = FilterUtils.filterToWhere(ComparisonOperation.GREATER_OR_EQUALS, select.whereColumn(MESSAGE_INDEX),
 					LEFT_MESSAGE_INDEX);
-		
+
 		if (!isRightIndexSelected && filter.getTimestampTo() != null)
 			select = FilterUtils.filterToWhere(ComparisonOperation.LESS_OR_EQUALS, select.whereColumn(MESSAGE_INDEX),
 					RIGHT_MESSAGE_INDEX);
@@ -268,10 +268,8 @@ public class MessageBatchQueryProvider
 				long fromIndex = getNearestMessageIndexBefore(tmOperator, instanceId,
 						filter.getStreamName().getValue(), directionFilter.getValue(), ts, attributes);
 				
-				if (fromIndex == Long.MIN_VALUE)
-					fromIndex = getNearestMessageIndexAfter(tmOperator, instanceId,
-							filter.getStreamName().getValue(), directionFilter.getValue(), ts, attributes);
-				else
+				if (fromIndex != Long.MIN_VALUE)
+					// Find batch index by nearest message index before
 					fromIndex = getMessageBatchIndex(operator, instanceId, filter.getStreamName().getValue(),
 							directionFilter.getValue(), fromIndex, attributes);
 				

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/dao/messages/TimeMessageEntity.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/dao/messages/TimeMessageEntity.java
@@ -62,15 +62,15 @@ public class TimeMessageEntity
 	@CqlName(DIRECTION)
 	private String direction;
 	
-	@PartitionKey(3)
+	@ClusteringColumn(0)
 	@CqlName(MESSAGE_DATE)
 	private LocalDate messageDate;
 	
-	@ClusteringColumn(0)
+	@ClusteringColumn(1)
 	@CqlName(MESSAGE_TIME)
 	private LocalTime messageTime;
 	
-	@ClusteringColumn(1)
+	@ClusteringColumn(2)
 	@CqlName(MESSAGE_INDEX)
 	private long messageIndex;
 	

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/dao/messages/TimeMessageOperator.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/dao/messages/TimeMessageOperator.java
@@ -33,14 +33,14 @@ import static com.exactpro.cradle.cassandra.StorageConstants.*;
 public interface TimeMessageOperator
 {
 	@Query("SELECT * FROM ${qualifiedTableId} WHERE "
-			+INSTANCE_ID+"=:instanceId AND "+STREAM_NAME+"=:streamName AND "+DIRECTION+"=:direction AND "+MESSAGE_DATE+"=:messageDate AND "
-			+MESSAGE_TIME+">=:messageTime ORDER BY "+MESSAGE_TIME+" ASC, "+MESSAGE_INDEX+" ASC limit 1")
+			+INSTANCE_ID+"=:instanceId AND "+STREAM_NAME+"=:streamName AND "+DIRECTION+"=:direction AND ("+MESSAGE_DATE+", "
+			+MESSAGE_TIME+")>=(:messageDate, :messageTime) ORDER BY " + MESSAGE_DATE + " ASC, " +MESSAGE_TIME+" ASC, "+MESSAGE_INDEX+" ASC limit 1")
 	CompletableFuture<TimeMessageEntity> getNearestMessageAfter(UUID instanceId, String streamName, LocalDate messageDate, String direction, 
 			LocalTime messageTime, Function<BoundStatementBuilder, BoundStatementBuilder> attributes);
 	
 	@Query("SELECT * FROM ${qualifiedTableId} WHERE "
-			+INSTANCE_ID+"=:instanceId AND "+STREAM_NAME+"=:streamName AND "+DIRECTION+"=:direction AND "+MESSAGE_DATE+"=:messageDate AND "
-			+MESSAGE_TIME+"<=:messageTime ORDER BY "+MESSAGE_TIME+" DESC, "+MESSAGE_INDEX+" DESC limit 1")
+			+INSTANCE_ID+"=:instanceId AND "+STREAM_NAME+"=:streamName AND "+DIRECTION+"=:direction AND ("+MESSAGE_DATE+", "
+			+MESSAGE_TIME+")<=(:messageDate, :messageTime) ORDER BY " + MESSAGE_DATE + " DESC, "+MESSAGE_TIME+" DESC, "+MESSAGE_INDEX+" DESC limit 1")
 	CompletableFuture<TimeMessageEntity> getNearestMessageBefore(UUID instanceId, String streamName, LocalDate messageDate, String direction, 
 			LocalTime messageTime, Function<BoundStatementBuilder, BoundStatementBuilder> attributes);
 	


### PR DESCRIPTION
Table time_messages_new has next PRIMARY KEY((instance_id, stream_name, direction), message_date, message_time, message_index).
Old table time_messages have next PRIMARY KEY((instance_id, stream_name, direction, message_date), message_time, message_index).