### PR TITLE
TH2-3206. Add column to books for storing schema version

### DIFF
--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraCradleStorage.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraCradleStorage.java
@@ -169,6 +169,15 @@ public class CassandraCradleStorage extends CradleStorage
 		{
 			for (BookEntity bookEntity : ops.getCradleBookOperator().getAll(readAttrs))
 			{
+				if(!bookEntity.getSchemaVersion().equals(settings.getSchemaVersion())) {
+					logger.warn("Unsupported schema version for the book \"{}\". Expected: {}, found: {}. Skipping",
+							bookEntity.getName(),
+							settings.getSchemaVersion(),
+							bookEntity.getSchemaVersion()
+					);
+					continue;
+				}
+
 				BookId bookId = new BookId(bookEntity.getName());
 				ops.addOperators(bookId, bookEntity.getKeyspaceName());
 				Collection<PageInfo> pages = loadPageInfo(bookId);

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraCradleStorage.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraCradleStorage.java
@@ -28,17 +28,9 @@ import com.exactpro.cradle.cassandra.dao.BookOperators;
 import com.exactpro.cradle.cassandra.dao.CassandraDataMapper;
 import com.exactpro.cradle.cassandra.dao.CassandraDataMapperBuilder;
 import com.exactpro.cradle.cassandra.dao.CradleOperators;
-import com.exactpro.cradle.cassandra.dao.books.BookEntity;
-import com.exactpro.cradle.cassandra.dao.books.PageEntity;
-import com.exactpro.cradle.cassandra.dao.books.PageNameEntity;
-import com.exactpro.cradle.cassandra.dao.books.PageNameOperator;
-import com.exactpro.cradle.cassandra.dao.books.PageOperator;
+import com.exactpro.cradle.cassandra.dao.books.*;
 import com.exactpro.cradle.cassandra.dao.messages.*;
-import com.exactpro.cradle.cassandra.dao.testevents.PageScopeEntity;
-import com.exactpro.cradle.cassandra.dao.testevents.PageScopesOperator;
-import com.exactpro.cradle.cassandra.dao.testevents.ScopeEntity;
-import com.exactpro.cradle.cassandra.dao.testevents.TestEventEntity;
-import com.exactpro.cradle.cassandra.dao.testevents.TestEventOperator;
+import com.exactpro.cradle.cassandra.dao.testevents.*;
 import com.exactpro.cradle.cassandra.iterators.PagedIterator;
 import com.exactpro.cradle.cassandra.keyspaces.BookKeyspaceCreator;
 import com.exactpro.cradle.cassandra.keyspaces.CradleInfoKeyspaceCreator;
@@ -55,18 +47,19 @@ import com.exactpro.cradle.intervals.IntervalsWorker;
 import com.exactpro.cradle.messages.*;
 import com.exactpro.cradle.resultset.CradleResultSet;
 import com.exactpro.cradle.testevents.StoredTestEvent;
-import com.exactpro.cradle.testevents.TestEventFilter;
 import com.exactpro.cradle.testevents.StoredTestEventId;
+import com.exactpro.cradle.testevents.TestEventFilter;
 import com.exactpro.cradle.testevents.TestEventToStore;
 import com.exactpro.cradle.utils.CradleStorageException;
 import com.exactpro.cradle.utils.TimeUtils;
-
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
-import java.time.*;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -193,7 +186,7 @@ public class CassandraCradleStorage extends CradleStorage
 	@Override
 	protected void doAddBook(BookToAdd newBook, BookId bookId) throws IOException
 	{
-		BookEntity bookEntity = new BookEntity(newBook);
+		BookEntity bookEntity = new BookEntity(newBook, settings.getSchemaVersion());
 		createBookKeyspace(bookEntity);
 		
 		try

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraStorageSettings.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraStorageSettings.java
@@ -19,12 +19,12 @@ package com.exactpro.cradle.cassandra;
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.exactpro.cradle.CradleStorage;
 import com.exactpro.cradle.cassandra.connection.NetworkTopologyStrategy;
-import com.exactpro.cradle.cassandra.retries.PageSizeAdjustingPolicy;
 import com.exactpro.cradle.cassandra.retries.SelectExecutionPolicy;
 
 public class CassandraStorageSettings
 {
 	public static final String CRADLE_INFO_KEYSPACE = "cradle_info",
+			SCHEMA_VERSION = "4.0.0",
 			BOOKS_TABLE = "books",
 			PAGES_TABLE = "pages",
 			PAGES_NAMES_TABLE = "pages_names",
@@ -54,6 +54,7 @@ public class CassandraStorageSettings
 	private final ConsistencyLevel writeConsistencyLevel,
 			readConsistencyLevel;
 	private String cradleInfoKeyspace,
+			schemaVersion,
 			booksTable,
 			pagesTable,
 			pagesNamesTable,
@@ -102,6 +103,7 @@ public class CassandraStorageSettings
 		this.readConsistencyLevel = readConsistencyLevel;
 
 		this.cradleInfoKeyspace = CRADLE_INFO_KEYSPACE;
+		this.schemaVersion = SCHEMA_VERSION;
 		this.booksTable = BOOKS_TABLE;
 		this.pagesTable = PAGES_TABLE;
 		this.pagesNamesTable = PAGES_NAMES_TABLE;
@@ -136,6 +138,7 @@ public class CassandraStorageSettings
 		this.readConsistencyLevel = settings.getReadConsistencyLevel();
 		
 		this.cradleInfoKeyspace = settings.getCradleInfoKeyspace();
+		this.schemaVersion = settings.getSchemaVersion();
 		this.booksTable = settings.getBooksTable();
 		this.pagesTable = settings.getPagesTable();
 		this.pagesNamesTable = settings.getPagesNamesTable();
@@ -197,6 +200,14 @@ public class CassandraStorageSettings
 		this.cradleInfoKeyspace = cradleInfoKeyspace;
 	}
 
+
+	public String getSchemaVersion() {
+		return schemaVersion;
+	}
+
+	public void setSchemaVersion(String schemaVersion) {
+		this.schemaVersion = schemaVersion;
+	}
 
 	public String getBooksTable()
 	{

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraStorageSettings.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraStorageSettings.java
@@ -205,9 +205,6 @@ public class CassandraStorageSettings
 		return schemaVersion;
 	}
 
-	public void setSchemaVersion(String schemaVersion) {
-		this.schemaVersion = schemaVersion;
-	}
 
 	public String getBooksTable()
 	{

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/StorageConstants.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/StorageConstants.java
@@ -31,6 +31,7 @@ public class StorageConstants
 			KEYSPACE_NAME = "keyspace_name",
 			DESCRIPTION = "description",
 			CREATED = "created",
+			SCHEMA_VERSION = "schema_version",
 			
 			MESSAGE_DATE = "message_date",
 			MESSAGE_TIME = "message_time",

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/dao/books/BookEntity.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/dao/books/BookEntity.java
@@ -16,15 +16,6 @@
 
 package com.exactpro.cradle.cassandra.dao.books;
 
-import static com.exactpro.cradle.cassandra.StorageConstants.CREATED;
-import static com.exactpro.cradle.cassandra.StorageConstants.DESCRIPTION;
-import static com.exactpro.cradle.cassandra.StorageConstants.FULLNAME;
-import static com.exactpro.cradle.cassandra.StorageConstants.KEYSPACE_NAME;
-import static com.exactpro.cradle.cassandra.StorageConstants.NAME;
-
-import java.time.Instant;
-import java.util.Collection;
-
 import com.datastax.oss.driver.api.mapper.annotations.CqlName;
 import com.datastax.oss.driver.api.mapper.annotations.Entity;
 import com.datastax.oss.driver.api.mapper.annotations.PartitionKey;
@@ -34,6 +25,11 @@ import com.exactpro.cradle.BookToAdd;
 import com.exactpro.cradle.PageInfo;
 import com.exactpro.cradle.utils.CradleStorageException;
 import org.apache.commons.lang3.StringUtils;
+
+import java.time.Instant;
+import java.util.Collection;
+
+import static com.exactpro.cradle.cassandra.StorageConstants.*;
 
 /**
  * Contains information about book as stored in "cradle" keyspace
@@ -58,18 +54,22 @@ public class BookEntity
 	
 	@CqlName(CREATED)
 	private Instant created;
-	
+
+	@CqlName(SCHEMA_VERSION)
+	private String schemaVersion;
+
 	public BookEntity()
 	{
 	}
 	
-	public BookEntity(BookToAdd book)
+	public BookEntity(BookToAdd book, String schemaVersion)
 	{
-		name = book.getName();
-		fullName = book.getFullName();
-		keyspaceName = toKeyspaceName(name);
-		desc = book.getDesc();
-		created = book.getCreated();
+		this.name = book.getName();
+		this.fullName = book.getFullName();
+		this.keyspaceName = toKeyspaceName(name);
+		this.desc = book.getDesc();
+		this.created = book.getCreated();
+		this.schemaVersion = schemaVersion;
 	}
 	
 	
@@ -126,8 +126,17 @@ public class BookEntity
 	{
 		this.created = created;
 	}
-	
-	
+
+
+	public String getSchemaVersion() {
+		return schemaVersion;
+	}
+
+	public void setSchemaVersion(String schemaVersion) {
+		this.schemaVersion = schemaVersion;
+	}
+
+
 	public BookInfo toBookInfo(Collection<PageInfo> pages) throws CradleStorageException
 	{
 		return new BookInfo(new BookId(name), fullName, desc, created, pages);

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/dao/books/CradleBookOperator.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/dao/books/CradleBookOperator.java
@@ -16,14 +16,14 @@
 
 package com.exactpro.cradle.cassandra.dao.books;
 
-import java.util.function.Function;
-
 import com.datastax.oss.driver.api.core.PagingIterable;
 import com.datastax.oss.driver.api.core.cql.BoundStatementBuilder;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.mapper.annotations.Dao;
 import com.datastax.oss.driver.api.mapper.annotations.Insert;
 import com.datastax.oss.driver.api.mapper.annotations.Select;
+
+import java.util.function.Function;
 
 @Dao
 public interface CradleBookOperator

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/keyspaces/CradleInfoKeyspaceCreator.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/keyspaces/CradleInfoKeyspaceCreator.java
@@ -62,6 +62,7 @@ public class CradleInfoKeyspaceCreator extends KeyspaceCreator
 				.withColumn(FULLNAME, DataTypes.TEXT)
 				.withColumn(KEYSPACE_NAME, DataTypes.TEXT)
 				.withColumn(DESCRIPTION, DataTypes.TEXT)
-				.withColumn(CREATED, DataTypes.TIMESTAMP));
+				.withColumn(CREATED, DataTypes.TIMESTAMP)
+				.withColumn(SCHEMA_VERSION, DataTypes.TEXT));
 	}
 }

--- a/cradle-cassandra/src/test/java/com/exactpro/cradle/cassandra/dao/books/BookEntityTest.java
+++ b/cradle-cassandra/src/test/java/com/exactpro/cradle/cassandra/dao/books/BookEntityTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 
 import java.time.Instant;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
 public class BookEntityTest
 {
@@ -42,7 +42,7 @@ public class BookEntityTest
 	@Test(dataProvider = "nameProvider")
 	public void keyspaceNameTest(String name, String keyspaceName)
 	{
-		BookEntity entity = new BookEntity(new BookToAdd(name, Instant.now(), "firstPage"));
+		BookEntity entity = new BookEntity(new BookToAdd(name, Instant.now(), "firstPage"), "Test Version");
 		assertEquals(entity.getKeyspaceName(), keyspaceName);
 	}
 


### PR DESCRIPTION
## Functionality

Cradle Cassandra will now internally add schema version whenever a book is stored via Cradle API. This is to make sure Cradle is not working with different schema versions when loading books. If a book is found with an invalid schema version, Cradle will log a warning and skip the book.

## Schema Changes

The column `schema_version`  is added to the table `books`.

## Testing

No new tests were added for this functionality.