### PR TITLE
TH2-3266. Change retry logic for checking keyspace readiness

### DIFF
--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/keyspaces/KeyspaceCreator.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/keyspaces/KeyspaceCreator.java
@@ -98,7 +98,7 @@ public abstract class KeyspaceCreator
 	private void awaitKeyspaceReady() throws CradleStorageException
 	{
 		int attempt = 0;
-		long timeRemaining = settings.getTimeout();
+		long timeRemaining = Math.max(KEYSPACE_WAIT_TIMEOUT, settings.getTimeout());
 
 		while(getKeyspaceMetadata() == null && timeRemaining > 0)
 		{

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/keyspaces/KeyspaceCreator.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/keyspaces/KeyspaceCreator.java
@@ -16,15 +16,6 @@
 
 package com.exactpro.cradle.cassandra.keyspaces;
 
-import java.io.IOException;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
-
-import com.exactpro.cradle.utils.CradleStorageException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.datastax.oss.driver.api.core.CqlIdentifier;
 import com.datastax.oss.driver.api.core.metadata.schema.KeyspaceMetadata;
 import com.datastax.oss.driver.api.core.metadata.schema.TableMetadata;
@@ -33,19 +24,25 @@ import com.datastax.oss.driver.api.querybuilder.schema.CreateKeyspace;
 import com.datastax.oss.driver.api.querybuilder.schema.CreateTable;
 import com.exactpro.cradle.cassandra.CassandraStorageSettings;
 import com.exactpro.cradle.cassandra.utils.QueryExecutor;
+import com.exactpro.cradle.utils.CradleStorageException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 public abstract class KeyspaceCreator
 {
 	private static final Logger logger = LoggerFactory.getLogger(KeyspaceCreator.class);
 	
-	public static final int ATTEMPTS_KEYSPACE_WAITING = 5;
-	public static final long MINIMAL_KEYSPACE_WAIT_TIMEOUT = 500;
+	public static final long KEYSPACE_WAIT_TIMEOUT = 500;
 	
 	private final String keyspace;
 	private final QueryExecutor queryExecutor;
 	private final CassandraStorageSettings settings;
-	private final long keyspaceWaitTimeout;
-	
+
 	private KeyspaceMetadata keyspaceMetadata;
 	
 	public KeyspaceCreator(String keyspace, QueryExecutor queryExecutor, CassandraStorageSettings settings)
@@ -53,7 +50,6 @@ public abstract class KeyspaceCreator
 		this.keyspace = keyspace;
 		this.queryExecutor = queryExecutor;
 		this.settings = settings;
-		this.keyspaceWaitTimeout = Math.max(MINIMAL_KEYSPACE_WAIT_TIMEOUT, settings.getTimeout() / ATTEMPTS_KEYSPACE_WAITING);
 	}
 	
 	protected abstract void createTables() throws IOException;
@@ -102,12 +98,16 @@ public abstract class KeyspaceCreator
 	private void awaitKeyspaceReady() throws CradleStorageException
 	{
 		int attempt = 0;
-		for (; getKeyspaceMetadata() == null && attempt < ATTEMPTS_KEYSPACE_WAITING; attempt++)
+		long timeRemaining = settings.getTimeout();
+
+		while(getKeyspaceMetadata() == null && timeRemaining > 0)
 		{
-			logger.debug("[{}] attempt to wait {}ms for the readiness of the keyspace", attempt + 1, keyspaceWaitTimeout);
+			attempt++;
+			logger.debug("[{}] attempt to wait {}ms for the readiness of the keyspace", attempt, KEYSPACE_WAIT_TIMEOUT);
 			try
 			{
-				TimeUnit.MILLISECONDS.sleep(keyspaceWaitTimeout);
+				TimeUnit.MILLISECONDS.sleep(Math.min(KEYSPACE_WAIT_TIMEOUT, timeRemaining));
+				timeRemaining -= KEYSPACE_WAIT_TIMEOUT;
 			}
 			catch (InterruptedException e)
 			{
@@ -118,8 +118,7 @@ public abstract class KeyspaceCreator
 		
 		if (getKeyspaceMetadata() == null)
 			throw new CradleStorageException(
-					"Keyspace '" + keyspace + "' unavailable after " + attempt * keyspaceWaitTimeout +
-							"ms of awaiting");
+					"Keyspace '" + keyspace + "' unavailable after " + settings.getTimeout() + "ms of awaiting");
 	}
 	
 	protected boolean isTableExists(String tableName)


### PR DESCRIPTION
## Functionality

Cradle Cassandra will now check for keyspace readiness every fixed time interval (currently 500 ms), for a maximum of **TIMEOUT** milliseconds, where **TIMEOUT** is the timeout specified in `CassandraStorageSettings`.

If the specified timeout is shorter than the **retry interval**, exactly one attempt will be made to wait. The first wait will **always** last for the fixed **retry interval**.

## Testing

No new tests were added for this functionality.