### PR TITLE
[TH2-3362] Add statistics table to keyspaces

### DIFF
--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraStorageSettings.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraStorageSettings.java
@@ -36,7 +36,8 @@ public class CassandraStorageSettings
 			PAGE_SCOPES_TABLE = "page_scopes",
 			TEST_EVENT_PARENT_INDEX = "test_event_parent_index",
 			LABELS_TABLE = "labels",
-			INTERVALS_TABLE = "intervals";
+			INTERVALS_TABLE = "intervals",
+			STATISTICS_TABLE = "statistics";
 	public static final long DEFAULT_TIMEOUT = 5000;
 	public static final ConsistencyLevel DEFAULT_CONSISTENCY_LEVEL = ConsistencyLevel.LOCAL_QUORUM;
 	public static final int DEFAULT_KEYSPACE_REPL_FACTOR = 1,
@@ -66,7 +67,8 @@ public class CassandraStorageSettings
 			pageScopesTable,
 			testEventParentIndex,
 			labelsTable,
-			intervalsTable;
+			intervalsTable,
+			statisticsTable;
 	private int keyspaceReplicationFactor;
 	
 	private int maxParallelQueries,
@@ -116,6 +118,7 @@ public class CassandraStorageSettings
 		this.testEventParentIndex = TEST_EVENT_PARENT_INDEX;
 		this.labelsTable = LABELS_TABLE;
 		this.intervalsTable = INTERVALS_TABLE;
+		this.statisticsTable = STATISTICS_TABLE;
 		
 		this.keyspaceReplicationFactor = DEFAULT_KEYSPACE_REPL_FACTOR;
 		this.maxParallelQueries = DEFAULT_MAX_PARALLEL_QUERIES;
@@ -151,7 +154,8 @@ public class CassandraStorageSettings
 		this.testEventParentIndex = settings.getTestEventParentIndex();
 		this.labelsTable = settings.getLabelsTable();
 		this.intervalsTable = settings.getIntervalsTable();
-		
+		this.statisticsTable = settings.getStatisticsTable();
+
 		this.keyspaceReplicationFactor = settings.getKeyspaceReplicationFactor();
 		this.maxParallelQueries = settings.getMaxParallelQueries();
 		this.resultPageSize = settings.getResultPageSize();
@@ -335,6 +339,15 @@ public class CassandraStorageSettings
 	public void setIntervalsTable(String intervalsTable)
 	{
 		this.intervalsTable = intervalsTable;
+	}
+
+
+	public String getStatisticsTable() {
+		return statisticsTable;
+	}
+
+	public void setStatisticsTable(String statisticsTable) {
+		this.statisticsTable = statisticsTable;
 	}
 
 

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/StorageConstants.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/StorageConstants.java
@@ -56,7 +56,13 @@ public class StorageConstants
 			TYPE = "type",
 			MESSAGES = "messages",
 			MESSAGES_PAGE = "messages_page",
-			
+
+			ENTITY_TYPE = "entity_type",
+			FRAME_TYPE = "frame_type",
+			FRAME_START = "frame_start",
+			ENTITY_COUNT = "entity_count",
+			ENTITY_SIZE = "entity_size",
+
 			START_TIMESTAMP = "start_timestamp",
 			END_TIMESTAMP = "end_timestamp",
 			BATCH_ID = "batch_id",

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/keyspaces/BookKeyspaceCreator.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/keyspaces/BookKeyspaceCreator.java
@@ -16,17 +16,18 @@
 
 package com.exactpro.cradle.cassandra.keyspaces;
 
-import java.io.IOException;
-
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.querybuilder.SchemaBuilder;
 import com.exactpro.cradle.cassandra.CassandraStorageSettings;
 import com.exactpro.cradle.cassandra.utils.QueryExecutor;
 
+import java.io.IOException;
+
 import static com.exactpro.cradle.cassandra.StorageConstants.*;
 
 public class BookKeyspaceCreator extends KeyspaceCreator
 {
+
 	public BookKeyspaceCreator(String keyspace, QueryExecutor exec, CassandraStorageSettings settings)
 	{
 		super(keyspace, exec, settings);
@@ -50,6 +51,8 @@ public class BookKeyspaceCreator extends KeyspaceCreator
 		
 		createLabelsTable();
 		createIntervals();
+
+		createStatistics();
 	}
 
 
@@ -191,5 +194,18 @@ public class BookKeyspaceCreator extends KeyspaceCreator
 				.withColumn(INTERVAL_LAST_UPDATE_TIME, DataTypes.TIME)
 				.withColumn(RECOVERY_STATE_JSON, DataTypes.TEXT)
 				.withColumn(INTERVAL_PROCESSED, DataTypes.BOOLEAN));
+	}
+
+	private void createStatistics() throws IOException
+	{
+		String tableName = getSettings().getStatisticsTable();
+		createTable(tableName, () -> SchemaBuilder.createTable(getKeyspace(), tableName).ifNotExists()
+				.withPartitionKey(SESSION_ALIAS, DataTypes.TEXT)
+				.withPartitionKey(DIRECTION, DataTypes.TEXT)
+				.withPartitionKey(ENTITY_TYPE, DataTypes.TINYINT)
+				.withPartitionKey(FRAME_TYPE, DataTypes.TINYINT)
+				.withClusteringColumn(FRAME_START, DataTypes.TIMESTAMP)
+				.withColumn(ENTITY_COUNT, DataTypes.COUNTER)
+				.withColumn(ENTITY_SIZE, DataTypes.COUNTER));
 	}
 }


### PR DESCRIPTION
## Functional Description

A table holding entity statistics will be created whenever a new book is added. This table will later be populated with data on entity (event, message) count and size.

## Testing

No new tests were added.