### PR TITLE
[TH2-3434] Remove double quotes for keyspace names

### DIFF
--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/dao/books/BookEntity.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/dao/books/BookEntity.java
@@ -24,7 +24,6 @@ import com.exactpro.cradle.BookInfo;
 import com.exactpro.cradle.BookToAdd;
 import com.exactpro.cradle.PageInfo;
 import com.exactpro.cradle.utils.CradleStorageException;
-import org.apache.commons.lang3.StringUtils;
 
 import java.time.Instant;
 import java.util.Collection;
@@ -145,8 +144,7 @@ public class BookEntity
 	private String toKeyspaceName(String name)
 	{
 		// Usually, book name is already checked in addBook() method in CradleStorage and has no invalid characters.
-		// It's enough to convert name to lower case, add prefix and wrap it with "
-		String nameWithPrefix = BOOK_NAME_PREFIX.concat(name.toLowerCase());
-		return StringUtils.wrap(nameWithPrefix, '\"');
+		// It's enough to convert name to lower case and add prefix.
+		return BOOK_NAME_PREFIX.concat(name.toLowerCase());
 	}
 }

--- a/cradle-cassandra/src/test/java/com/exactpro/cradle/cassandra/dao/books/BookEntityTest.java
+++ b/cradle-cassandra/src/test/java/com/exactpro/cradle/cassandra/dao/books/BookEntityTest.java
@@ -30,12 +30,12 @@ public class BookEntityTest
 	protected Object[][] nameProvider()
 	{
 		return new Object[][] {
-				{"_", "\"book__\""},
-				{"4", "\"book_4\""},
-				{"name", "\"book_name\""},
-				{"Name", "\"book_name\""},
-				{"NaMe", "\"book_name\""},
-				{"book_NaMe", "\"book_book_name\""},
+				{"_", "book__"},
+				{"4", "book_4"},
+				{"name", "book_name"},
+				{"Name", "book_name"},
+				{"NaMe", "book_name"},
+				{"book_NaMe", "book_book_name"},
 		};
 	}
 


### PR DESCRIPTION
## Functional Description

Generated keyspace names for books will no longer be wrapped in double quotes. 
Cradle will retain backwards compatibility with existing books.

## Testing

Tests verifying keyspace name generation were updated. No new tests were added.