### PR TITLE
[TH2-4877] Release 3.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cradle API (3.1.4)
+# Cradle API (3.1.5)
 
 ## Overview
 
@@ -124,9 +124,10 @@ Stream name is similar to session alias, i.e. is a name for a pair of connected 
 
 Direction is "first" or "second" depending on endpoint that generated the message.
 
-Message index is a number, incremented for each new message within the same stream and direction.
+Message index is a positive number, incremented for each new message within the same stream and direction.
 
-I.e. if for the stream name="stream1" and direction="first" the last message index was 10, the next message index for this stream name and direction is expected to be 11. It can be different, but greater than 10.
+I.e. if for the stream name="stream1" and direction="first" the last message index was 10, the next message index for
+this stream name and direction is expected to be 11. It can be different, but greater than 10.
 
 Messages can have metadata as a set of key-value string pairs, providing additional details about the message. Metadata cannot be used in any search requests or filtering.
 
@@ -134,13 +135,22 @@ Messages can have metadata as a set of key-value string pairs, providing additio
 
 Test events in Cradle can be stored separately or in batches, if an event has complex hierarchical structure.
 
-A test event can have a reference to its parent, thus forming a hierarchical structure. Events that started the test execution have no parent and are called "root test events".
+A test event can have a reference to its parent, thus forming a hierarchical structure. Events that started the test
+execution have no parent and are called "root test events".
 
-Events in a batch can have a reference only to the parent of the batch or other test events from the same batch. Events outside of the batch should not reference events within the batch.
+Events in a batch can have a reference only to the parent of the batch or other test events from the same batch. Events
+outside of the batch should not reference events within the batch.
 
-Test events have mandatory parameters that are verified when storing an event. These are: id, name (for non-batch events), start timestamp.
+Test events have mandatory parameters that are verified when storing an event. These are: id, name (for non-batch
+events), start timestamp.
 
 ## Release notes
+
+### 3.1.5
+
++ Add check for negative value in **StoredMessageId#index** field
+  (the negative value causes incorrect serialization and does not make much sense - it was decided to prohibit them at
+  all)
 
 ### 3.1.4
 

--- a/cradle-core/src/main/java/com/exactpro/cradle/messages/StoredMessageId.java
+++ b/cradle-core/src/main/java/com/exactpro/cradle/messages/StoredMessageId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2020 Exactpro (Exactpro Systems Limited)
+ * Copyright 2020-2023 Exactpro (Exactpro Systems Limited)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,60 +26,56 @@ import com.exactpro.cradle.utils.CradleIdException;
  * All messages have sequenced index, scoped by direction and stream related to the message.
  * Message index in conjunction with stream name and direction of the message form the message ID
  */
-public class StoredMessageId implements Serializable
-{
+public class StoredMessageId implements Serializable {
 	private static final long serialVersionUID = -6856521491563727644L;
-	
+
 	private final String streamName;
 	private final Direction direction;
 	private final long index;
-	
-	public StoredMessageId(String streamName, Direction direction, long index)
-	{
+
+	public StoredMessageId(String streamName, Direction direction, long index) {
 		this.streamName = streamName;
 		this.direction = direction;
+		if (index < 0) {
+			throw new IllegalArgumentException(String.format("illegal index %d for %s:%s",
+					index, streamName, direction.getLabel()));
+		}
 		this.index = index;
 	}
-	
-	
-	public static StoredMessageId fromString(String id) throws CradleIdException
-	{
+
+
+	public static StoredMessageId fromString(String id) throws CradleIdException {
 		String[] parts = StoredMessageIdUtils.splitParts(id);
 		if (parts.length < 3)
-			throw new CradleIdException("Message ID ("+id+") should contain stream name, direction and message index delimited with '"+StoredMessageBatchId.IDS_DELIMITER+"'");
-		
+			throw new CradleIdException("Message ID (" + id + ") should contain stream name, direction and message index delimited with '" + StoredMessageBatchId.IDS_DELIMITER + "'");
+
 		long index = StoredMessageIdUtils.getIndex(parts);
 		Direction direction = StoredMessageIdUtils.getDirection(parts);
 		String streamName = StoredMessageIdUtils.getStreamName(parts);
 		return new StoredMessageId(streamName, direction, index);
 	}
-	
-	
-	public String getStreamName()
-	{
+
+
+	public String getStreamName() {
 		return streamName;
 	}
-	
-	public Direction getDirection()
-	{
+
+	public Direction getDirection() {
 		return direction;
 	}
-	
-	public long getIndex()
-	{
+
+	public long getIndex() {
 		return index;
 	}
-	
-	
+
+
 	@Override
-	public String toString()
-	{
-		return streamName+StoredMessageBatchId.IDS_DELIMITER+direction.getLabel()+StoredMessageBatchId.IDS_DELIMITER+index;
+	public String toString() {
+		return streamName + StoredMessageBatchId.IDS_DELIMITER + direction.getLabel() + StoredMessageBatchId.IDS_DELIMITER + index;
 	}
-	
+
 	@Override
-	public int hashCode()
-	{
+	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + ((direction == null) ? 0 : direction.hashCode());
@@ -87,10 +83,9 @@ public class StoredMessageId implements Serializable
 		result = prime * result + ((streamName == null) ? 0 : streamName.hashCode());
 		return result;
 	}
-	
+
 	@Override
-	public boolean equals(Object obj)
-	{
+	public boolean equals(Object obj) {
 		if (this == obj)
 			return true;
 		if (obj == null)
@@ -102,8 +97,7 @@ public class StoredMessageId implements Serializable
 			return false;
 		if (index != other.index)
 			return false;
-		if (streamName == null)
-		{
+		if (streamName == null) {
 			if (other.streamName != null)
 				return false;
 		} else if (!streamName.equals(other.streamName))

--- a/cradle-core/src/main/java/com/exactpro/cradle/serialization/EventMessageIdDeserializer.java
+++ b/cradle-core/src/main/java/com/exactpro/cradle/serialization/EventMessageIdDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2021 Exactpro (Exactpro Systems Limited)
+ * Copyright 2021-2023 Exactpro (Exactpro Systems Limited)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,14 +35,12 @@ import static com.exactpro.cradle.serialization.Serialization.NOT_SUPPORTED_PROT
 public class EventMessageIdDeserializer {
 
 
-	public static Collection<StoredMessageId> deserializeLinkedMessageIds(byte[] bytes) throws IOException
-	{
+	public static Collection<StoredMessageId> deserializeLinkedMessageIds(byte[] bytes) throws IOException {
 		if (bytes == null || bytes.length == 0)
 			return null;
 
 		try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
-			 DataInputStream dis = new DataInputStream(bais))
-		{
+			 DataInputStream dis = new DataInputStream(bais)) {
 			byte version = dis.readByte();
 			if (version != VERSION) {
 				throw new SerializationException(String.format(NOT_SUPPORTED_PROTOCOL_FORMAT, "linkedMessageIds",
@@ -50,12 +48,11 @@ public class EventMessageIdDeserializer {
 			}
 			byte mark = dis.readByte();
 			if (mark != SINGLE_EVENT_LINKS)
-				throw new IOException("Unexpected data mark. Expected "+SINGLE_EVENT_LINKS+", got "+mark);
+				throw new IOException("Unexpected data mark. Expected " + SINGLE_EVENT_LINKS + ", got " + mark);
 
 			int size = dis.readInt();
 			Collection<StoredMessageId> result = new ArrayList<>(size);
-			if (size == 1)
-			{
+			if (size == 1) {
 				String streamName = CradleSerializationUtils.readString(dis);
 				Direction direction = readDirection(dis);
 				if (direction == null)
@@ -64,8 +61,7 @@ public class EventMessageIdDeserializer {
 				return result;
 			}
 
-			while (result.size() < size)
-			{
+			while (result.size() < size) {
 				String streamName = CradleSerializationUtils.readString(dis);
 				readDirectionIds(streamName, result, dis);
 			}
@@ -73,35 +69,31 @@ public class EventMessageIdDeserializer {
 		}
 	}
 
-	public static Map<StoredTestEventId, Collection<StoredMessageId>> deserializeBatchLinkedMessageIds(byte[] bytes) throws IOException
-	{
+	public static Map<StoredTestEventId, Collection<StoredMessageId>> deserializeBatchLinkedMessageIds(byte[] bytes) throws IOException {
 		if (bytes == null || bytes.length == 0)
 			return null;
 
 		try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
-			 DataInputStream dis = new DataInputStream(bais))
-		{
+			 DataInputStream dis = new DataInputStream(bais)) {
 			byte version = dis.readByte();
 			if (version != VERSION)
 				throw new SerializationException(String.format(NOT_SUPPORTED_PROTOCOL_FORMAT, "linkedMessageIds",
 						version, VERSION));
 			byte mark = dis.readByte();
 			if (mark != BATCH_LINKS)
-				throw new IOException("Unexpected data mark. Expected "+BATCH_LINKS+", got "+mark);
+				throw new IOException("Unexpected data mark. Expected " + BATCH_LINKS + ", got " + mark);
 
 			int eventsTotal = dis.readInt();
 			Map<StoredTestEventId, Collection<StoredMessageId>> result = new HashMap<>(eventsTotal);
 
 			Map<Integer, String> mapping = readMapping(dis);
 
-			while (result.size() < eventsTotal)
-			{
+			while (result.size() < eventsTotal) {
 				StoredTestEventId eventId = new StoredTestEventId(CradleSerializationUtils.readString(dis));
 				int size = dis.readInt();
 				Collection<StoredMessageId> eventLinks = new ArrayList<>(size);
 
-				while (eventLinks.size() < size)
-				{
+				while (eventLinks.size() < size) {
 					int index = dis.readShort();
 					String streamName = mapping.get(index);
 					readDirectionIds(streamName, eventLinks, dis);
@@ -113,12 +105,10 @@ public class EventMessageIdDeserializer {
 		}
 	}
 
-	private static Map<Integer, String> readMapping(DataInputStream dis) throws IOException
-	{
+	private static Map<Integer, String> readMapping(DataInputStream dis) throws IOException {
 		int size = dis.readShort();
 		Map<Integer, String> result = new HashMap<>(size);
-		for (int i = 0; i < size; i++)
-		{
+		for (int i = 0; i < size; i++) {
 			String streamName = CradleSerializationUtils.readString(dis);
 			int index = dis.readShort();
 			result.put(index, streamName);
@@ -126,15 +116,13 @@ public class EventMessageIdDeserializer {
 		return result;
 	}
 
-	private static void readDirectionIds(String streamName, Collection<StoredMessageId> result, DataInputStream dis) throws IOException
-	{
+	private static void readDirectionIds(String streamName, Collection<StoredMessageId> result, DataInputStream dis) throws IOException {
 		Direction direction;
 		while ((direction = readDirection(dis)) != null)
 			readDirectionIds(direction, streamName, result, dis);
 	}
 
-	private static Direction readDirection(DataInputStream dis) throws IOException
-	{
+	private static Direction readDirection(DataInputStream dis) throws IOException {
 		byte direction = dis.readByte();
 		if (direction == 0)
 			return null;
@@ -142,33 +130,32 @@ public class EventMessageIdDeserializer {
 			return Direction.FIRST;
 		else if (direction == DIRECTION_SECOND)
 			return Direction.SECOND;
-		throw new IOException("Unknown direction - "+direction);
+		throw new IOException("Unknown direction - " + direction);
 	}
 
 	private static void readDirectionIds(Direction direction, String streamName,
-										 Collection<StoredMessageId> result, DataInputStream dis) throws IOException
-	{
+										 Collection<StoredMessageId> result, DataInputStream dis) throws IOException {
 		int size = dis.readInt();
 		int count = 0;
-		while (count < size)
-		{
+		while (count < size) {
 			byte mark = dis.readByte();
-			if (mark == SINGLE_ID)
-			{
-				result.add(new StoredMessageId(streamName, direction, dis.readLong()));
-				count++;
-			}
-			else
-			{
-				long start = dis.readLong(),
-						end = dis.readLong();
-				for (long i = start; i <= end; i++)
-				{
-					result.add(new StoredMessageId(streamName, direction, i));
+			switch (mark) {
+				case SINGLE_ID:
+					result.add(new StoredMessageId(streamName, direction, dis.readLong()));
 					count++;
-				}
+					break;
+				case RANGE_OF_IDS:
+					long start = dis.readLong();
+					long end = dis.readLong();
+					for (long i = start; i <= end; i++) {
+						result.add(new StoredMessageId(streamName, direction, i));
+						count++;
+					}
+					break;
+				default:
+					throw new IllegalStateException("unknown id mark " + mark);
 			}
 		}
 	}
-	
+
 }

--- a/cradle-core/src/main/java/com/exactpro/cradle/serialization/EventMessageIdSerializer.java
+++ b/cradle-core/src/main/java/com/exactpro/cradle/serialization/EventMessageIdSerializer.java
@@ -41,29 +41,23 @@ public class EventMessageIdSerializer {
 
 
 	public static byte[] serializeLinkedMessageIds(Collection<StoredMessageId> ids)
-			throws IOException
-	{
+			throws IOException {
 		if (ids == null || ids.isEmpty())
 			return null;
 
 		byte[] result;
 		try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
-			 DataOutputStream dos = new DataOutputStream(baos))
-		{
+			 DataOutputStream dos = new DataOutputStream(baos)) {
 			writeIdsStart(ids, dos);
 
-			if (ids.size() == 1)
-			{
+			if (ids.size() == 1) {
 				StoredMessageId id = ids.iterator().next();
 				CradleSerializationUtils.writeString(id.getStreamName(), dos);
 				dos.writeByte(id.getDirection() == Direction.FIRST ? DIRECTION_FIRST: DIRECTION_SECOND);
 				dos.writeLong(id.getIndex());
-			}
-			else
-			{
+			} else {
 				Map<String, Pair<List<Long>, List<Long>>> byStream = divideIdsByStream(ids);
-				for (Map.Entry<String, Pair<List<Long>, List<Long>>> streamIds : byStream.entrySet())
-				{
+				for (Map.Entry<String, Pair<List<Long>, List<Long>>> streamIds : byStream.entrySet()) {
 					CradleSerializationUtils.writeString(streamIds.getKey(), dos);
 					writeDirectionIds(streamIds.getValue(), dos);
 				}
@@ -76,27 +70,23 @@ public class EventMessageIdSerializer {
 	}
 
 	public static byte[] serializeBatchLinkedMessageIds(Map<StoredTestEventId, Collection<StoredMessageId>> ids)
-			throws IOException
-	{
+			throws IOException {
 		if (ids == null || ids.isEmpty())
 			return null;
 
 		byte[] result;
 		try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
-			 DataOutputStream dos = new DataOutputStream(baos))
-		{
+			 DataOutputStream dos = new DataOutputStream(baos)) {
 			writeIdsStart(ids, dos);
 
 			Map<String, Integer> mapping = getStreams(ids);
 			writeMapping(mapping, dos);
-			for (Map.Entry<StoredTestEventId, Collection<StoredMessageId>> eventMessages : ids.entrySet())
-			{
+			for (Map.Entry<StoredTestEventId, Collection<StoredMessageId>> eventMessages : ids.entrySet()) {
 				CradleSerializationUtils.writeString(eventMessages.getKey().getId(), dos);
 				dos.writeInt(eventMessages.getValue().size());
 
 				Map<String, Pair<List<Long>, List<Long>>> byStream = divideIdsByStream(eventMessages.getValue());
-				for (Map.Entry<String, Pair<List<Long>, List<Long>>> streamIds : byStream.entrySet())
-				{
+				for (Map.Entry<String, Pair<List<Long>, List<Long>>> streamIds : byStream.entrySet()) {
 					dos.writeShort(mapping.get(streamIds.getKey()));
 					writeDirectionIds(streamIds.getValue(), dos);
 				}
@@ -108,22 +98,19 @@ public class EventMessageIdSerializer {
 		return result;
 	}
 
-	private static void writeIdsStart(Collection<StoredMessageId> ids, DataOutputStream dos) throws IOException
-	{
+	private static void writeIdsStart(Collection<StoredMessageId> ids, DataOutputStream dos) throws IOException {
 		dos.writeByte(VERSION);
 		dos.writeByte(SINGLE_EVENT_LINKS);
 		dos.writeInt(ids.size());
 	}
 
-	private static void writeIdsStart(Map<StoredTestEventId, Collection<StoredMessageId>> ids, DataOutputStream dos) throws IOException
-	{
+	private static void writeIdsStart(Map<StoredTestEventId, Collection<StoredMessageId>> ids, DataOutputStream dos) throws IOException {
 		dos.writeByte(VERSION);
 		dos.writeByte(BATCH_LINKS);
 		dos.writeInt(ids.size());
 	}
 
-	private static void writeDirectionIds(Pair<List<Long>, List<Long>> firstSecondIds, DataOutputStream dos) throws IOException
-	{
+	private static void writeDirectionIds(Pair<List<Long>, List<Long>> firstSecondIds, DataOutputStream dos) throws IOException {
 		List<Long> first = firstSecondIds.getLeft(),
 				second = firstSecondIds.getRight();
 		if (first != null && first.size() > 0)
@@ -133,30 +120,28 @@ public class EventMessageIdSerializer {
 		dos.writeByte(END_OF_DATA);
 	}
 
-	private static void writeDirectionIds(Direction direction, List<Long> ids, DataOutputStream dos) throws IOException
-	{
+	private static void writeDirectionIds(Direction direction, List<Long> ids, DataOutputStream dos) throws IOException {
 		dos.writeByte(direction == Direction.FIRST ? DIRECTION_FIRST : DIRECTION_SECOND);
 		dos.writeInt(ids.size());
 
 		long start = -1,
 				prevId = -1;
-		for (long id : ids)
-		{
-			if (start < 0)
-			{
+		for (long id : ids) {
+			if (id < 0) {
+				throw new IllegalArgumentException("prohibited sequence " + id + " for direction " + direction);
+			}
+			if (start < 0) {
 				start = id;
 				prevId = id;
 				continue;
 			}
 
-			if (id != prevId+1)
-			{
+			if (id != prevId + 1) {
 				writeIds(start, prevId, dos);
 
 				start = id;
 				prevId = id;
-			}
-			else
+			} else
 				prevId = id;
 		}
 
@@ -164,27 +149,21 @@ public class EventMessageIdSerializer {
 			writeIds(start, prevId, dos);
 	}
 
-	private static void writeIds(long start, long end, DataOutputStream dos) throws IOException
-	{
-		if (start == end)
-		{
+	private static void writeIds(long start, long end, DataOutputStream dos) throws IOException {
+		if (start == end) {
 			dos.writeByte(SINGLE_ID);
 			dos.writeLong(start);
-		}
-		else
-		{
+		} else {
 			dos.writeByte(RANGE_OF_IDS);
 			dos.writeLong(start);
 			dos.writeLong(end);
 		}
 	}
 
-	private static Map<String, Pair<List<Long>, List<Long>>> divideIdsByStream(Collection<StoredMessageId> ids)
-	{
+	private static Map<String, Pair<List<Long>, List<Long>>> divideIdsByStream(Collection<StoredMessageId> ids) {
 		int inititalCapacity = ids.size() / 2;
 		Map<String, Pair<List<Long>, List<Long>>> result = new HashMap<>();
-		for (StoredMessageId id : ids)
-		{
+		for (StoredMessageId id : ids) {
 			Pair<List<Long>, List<Long>> storage = result.computeIfAbsent(id.getStreamName(),
 					sn -> new ImmutablePair<>(new ArrayList<Long>(inititalCapacity), new ArrayList<Long>(inititalCapacity)));
 			if (id.getDirection() == Direction.FIRST)
@@ -193,8 +172,7 @@ public class EventMessageIdSerializer {
 				storage.getRight().add(id.getIndex());
 		}
 
-		for (Pair<List<Long>, List<Long>> streamIds : result.values())
-		{
+		for (Pair<List<Long>, List<Long>> streamIds : result.values()) {
 			Collections.sort(streamIds.getLeft());
 			Collections.sort(streamIds.getRight());
 		}
@@ -202,8 +180,7 @@ public class EventMessageIdSerializer {
 		return result;
 	}
 
-	private static Map<String, Integer> getStreams(Map<StoredTestEventId, Collection<StoredMessageId>> ids)
-	{
+	private static Map<String, Integer> getStreams(Map<StoredTestEventId, Collection<StoredMessageId>> ids) {
 		Set<String> streams = new HashSet<>();
 		ids.values().forEach(eventIds -> eventIds.forEach(id -> streams.add(id.getStreamName())));
 
@@ -213,14 +190,12 @@ public class EventMessageIdSerializer {
 		return result;
 	}
 
-	private static void writeMapping(Map<String, Integer> mapping, DataOutputStream dos) throws IOException
-	{
+	private static void writeMapping(Map<String, Integer> mapping, DataOutputStream dos) throws IOException {
 		dos.writeShort(mapping.size());
-		for (Map.Entry<String, Integer> m : mapping.entrySet())
-		{
+		for (Map.Entry<String, Integer> m : mapping.entrySet()) {
 			CradleSerializationUtils.writeString(m.getKey(), dos);
 			dos.writeShort(m.getValue());
 		}
 	}
-	
+
 }

--- a/cradle-core/src/test/java/com/exactpro/cradle/serialization/TestEventMessageIdDeserializer.java
+++ b/cradle-core/src/test/java/com/exactpro/cradle/serialization/TestEventMessageIdDeserializer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.cradle.serialization;
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+public class TestEventMessageIdDeserializer {
+
+    @Test(
+            expectedExceptions = IllegalStateException.class,
+            expectedExceptionsMessageRegExp = "unknown id mark 3"
+    )
+    public void testDeserializeBatchLinkedMessageIds() throws IOException {
+        byte[] data = {
+                0x01,
+                0x02,
+                0x00, 0x00, 0x00, 0x01, // link count
+                0x00, 0x01, // mapping
+                0x00, 0x01, // stream name length
+                (byte) 'A',
+                0x00, 0x00, // mapping index
+                0x00, 0x01, // event ID length
+                (byte) 'E',
+                0x00, 0x00, 0x00, 0x01, // ids count
+                0x00, 0x00, // mapping index
+                0x02, // direction
+                0x00, 0x00, 0x00, 0x01, // ids for dir
+                0x03, // UNKNOWN ID TYPE,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // index,
+                0x00, // end of data
+        };
+        EventMessageIdDeserializer.deserializeBatchLinkedMessageIds(data);
+    }
+}

--- a/cradle-core/src/test/java/com/exactpro/cradle/serialization/TestEventMessageIdSerializer.java
+++ b/cradle-core/src/test/java/com/exactpro/cradle/serialization/TestEventMessageIdSerializer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.cradle.serialization;
+
+import com.exactpro.cradle.Direction;
+import com.exactpro.cradle.messages.StoredMessageId;
+import com.exactpro.cradle.testevents.StoredTestEventId;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+
+public class TestEventMessageIdSerializer {
+
+    @Test(
+            expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = "prohibited sequence -9223372036854775808 for direction FIRST"
+    )
+    public void testSerializeBatchLinkedMessageIds() throws IOException, NoSuchFieldException, IllegalAccessException {
+        var messageId = new StoredMessageId("test", Direction.FIRST, 0);
+        setNegativeIndex(messageId, Long.MIN_VALUE);
+
+        EventMessageIdSerializer.serializeBatchLinkedMessageIds(Map.of(
+                new StoredTestEventId("test"), List.of(messageId)
+        ));
+    }
+
+    private static void setNegativeIndex(StoredMessageId messageId, long index) throws NoSuchFieldException, IllegalAccessException {
+        // prepare illegal state for message ID
+        Field indexField = messageId.getClass().getDeclaredField("index");
+        indexField.setAccessible(true);
+        indexField.set(messageId, index);
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-release_version = 3.1.4
-description = 'Cradle API'
+release_version=3.1.5
+description='Cradle API'
 
 
 vcs_url=https://github.com/th2-net/cradleapi


### PR DESCRIPTION
The negative message index in the attached message IDs to an event breaks its serialization. Because of that and because it does not really make any sense to have a negative message index it was decided to prohibit such indexes