### PR TITLE
Skip unwelcome words CI on dependabot PRs

### DIFF
--- a/.github/workflows/ci-unwelcome-words.yml
+++ b/.github/workflows/ci-unwelcome-words.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-20.04
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Dependabot does not have access to the CI. Also, it cannot introduce anything forbidden