### PR TITLE
[TH2-5286] Provided option to limit parallel statistic tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Overview (5.4.4)
+# Overview (5.5.0)
 
 Cradle API is used to work with Cradle - the datalake where th2 stores its data.
 
@@ -208,6 +208,15 @@ Test events have mandatory parameters that are verified when storing an event. T
   * cause: EXPLICIT, REPLACED, COLLECTED, EXPIRED, SIZE
 
 ## Release notes
+
+### 5.5.0
+
+* Provided option to limit parallel statistic tasks
+  * Added `counterPersistenceMaxParallelQueries` option to configure how many queries can be executed in parallel for statistic persistence.
+* Updated:
+  * th2 gradle plugin: `0.2.4` (bom: `4.11.0`)
+  * task-utils: `0.1.4`
+  * caffeine: `3.2.0`
 
 ### 5.4.4
 * Fixed the problem - page cache doesn't work correct when storage has removed page(s)

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraCradleStorage.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraCradleStorage.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2023-2024 Exactpro (Exactpro Systems Limited)
+ *  Copyright 2023-2025 Exactpro (Exactpro Systems Limited)
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -227,7 +227,9 @@ public class CassandraCradleStorage extends CradleStorage
 					settings.getEventBatchDurationMillis());
 
 			WorkerSupplies ws = new WorkerSupplies(settings, operators, composingService, bookCache, selectExecutor, writeAttrs, readAttrs, batchWriteAttrs);
-			statisticsWorker = new StatisticsWorker(ws, settings.getCounterPersistenceInterval());
+			statisticsWorker = new StatisticsWorker(ws,
+					settings.getCounterPersistenceInterval(),
+					settings.getCounterPersistenceMaxParallelQueries());
 			eventsWorker = new EventsWorker(ws, statisticsWorker, eventBatchDurationWorker);
 			messagesWorker = new MessagesWorker(ws, statisticsWorker, statisticsWorker);
 			statisticsWorker.start();

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraStorageSettings.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/CassandraStorageSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 Exactpro (Exactpro Systems Limited)
+ * Copyright 2020-2025 Exactpro (Exactpro Systems Limited)
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ public class CassandraStorageSettings extends CoreStorageSettings {
     public static final int DEFAULT_EVENT_BATCH_DURATION_CACHE_SIZE = 5_000;
     public static final int DEFAULT_PAGE_GROUPS_CACHE_SIZE = 10_000;
     public static final int DEFAULT_COUNTER_PERSISTENCE_INTERVAL_MS = 15000;
+    public static final int DEFAULT_COUNTER_PERSISTENCE_MAX_PARALLEL_QUERIES = 128;
     public static final long DEFAULT_EVENT_BATCH_DURATION_MILLIS = 5_000;
     public static final long DEFAULT_TIMEOUT = 5000;
     public static final CompressionType DEFAULT_COMPRESSION_TYPE = CompressionType.LZ4;
@@ -92,6 +93,7 @@ public class CassandraStorageSettings extends CoreStorageSettings {
     private int groupsCacheSize = DEFAULT_GROUPS_CACHE_SIZE;
     private int eventBatchDurationCacheSize = DEFAULT_EVENT_BATCH_DURATION_CACHE_SIZE;
     private int counterPersistenceInterval = DEFAULT_COUNTER_PERSISTENCE_INTERVAL_MS;
+    private int counterPersistenceMaxParallelQueries = DEFAULT_COUNTER_PERSISTENCE_MAX_PARALLEL_QUERIES;
     private int composingServiceThreads = DEFAULT_COMPOSING_SERVICE_THREADS;
 
     private SelectExecutionPolicy multiRowResultExecutionPolicy;
@@ -152,6 +154,7 @@ public class CassandraStorageSettings extends CoreStorageSettings {
         this.groupsCacheSize = settings.getGroupsCacheSize();
         this.sessionStatisticsCacheSize = settings.getSessionStatisticsCacheSize();
         this.counterPersistenceInterval = settings.getCounterPersistenceInterval();
+        this.counterPersistenceMaxParallelQueries = settings.getCounterPersistenceMaxParallelQueries();
         this.composingServiceThreads = settings.getComposingServiceThreads();
         setBookRefreshIntervalMillis(settings.getBookRefreshIntervalMillis());
         this.eventBatchDurationMillis = settings.getEventBatchDurationMillis();
@@ -344,6 +347,14 @@ public class CassandraStorageSettings extends CoreStorageSettings {
         this.counterPersistenceInterval = counterPersistenceInterval;
     }
 
+    public int getCounterPersistenceMaxParallelQueries() {
+        return counterPersistenceMaxParallelQueries;
+    }
+
+    public void setCounterPersistenceMaxParallelQueries(int counterPersistenceMaxParallelQueries) {
+        this.counterPersistenceMaxParallelQueries = counterPersistenceMaxParallelQueries;
+    }
+
     public int getComposingServiceThreads() {
         return composingServiceThreads;
     }
@@ -423,6 +434,7 @@ public class CassandraStorageSettings extends CoreStorageSettings {
                 ", groupsCacheSize=" + groupsCacheSize +
                 ", eventBatchDurationCacheSize=" + eventBatchDurationCacheSize +
                 ", counterPersistenceInterval=" + counterPersistenceInterval +
+                ", counterPersistenceMaxParallelQueries=" + counterPersistenceMaxParallelQueries +
                 ", composingServiceThreads=" + composingServiceThreads +
                 ", multiRowResultExecutionPolicy=" + multiRowResultExecutionPolicy +
                 ", singleRowResultExecutionPolicy=" + singleRowResultExecutionPolicy +

--- a/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/workers/StatisticsWorker.java
+++ b/cradle-cassandra/src/main/java/com/exactpro/cradle/cassandra/workers/StatisticsWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 Exactpro (Exactpro Systems Limited)
+ * Copyright 2020-2025 Exactpro (Exactpro Systems Limited)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,12 +55,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 public class StatisticsWorker implements Runnable, EntityStatisticsCollector, MessageStatisticsCollector, SessionStatisticsCollector {
 
-    private static final Logger logger = LoggerFactory.getLogger(StatisticsWorker.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(StatisticsWorker.class);
     private static final int MAX_BATCH_STATEMENTS = 16384;
 
     private static final ThreadFactory THREAD_FACTORY = new ThreadFactoryBuilder().setNameFormat("cradle-statistics-worker-%d").build();
@@ -72,27 +71,27 @@ public class StatisticsWorker implements Runnable, EntityStatisticsCollector, Me
     private final Function<BatchStatementBuilder, BatchStatementBuilder> batchWriteAttrs;
     private final boolean isEnabled;
 
-    public StatisticsWorker (WorkerSupplies workerSupplies, long persistenceInterval) {
-        this.futures = new FutureTracker<>();
+    public StatisticsWorker (WorkerSupplies workerSupplies, long persistenceInterval, int parallel) {
+        this.futures = FutureTracker.create(parallel);
         this.operators = workerSupplies.getOperators();
         this.batchWriteAttrs = workerSupplies.getBatchWriteAttrs();
         this.interval = persistenceInterval;
         this.bookCounterCaches = new ConcurrentHashMap<>();
         this.isEnabled = (interval != 0);
-        logger.info("Statistics worker status is {}", this.isEnabled);
+        LOGGER.info("Statistics worker status is {}", this.isEnabled);
     }
 
     private ScheduledExecutorService executorService;
     public void start() {
         if (!isEnabled) {
-            logger.info("Counter persistence service is disabled");
+            LOGGER.info("Counter persistence service is disabled");
             return;
         }
 
-        logger.info("Starting executor for StatisticsWorker");
+        LOGGER.info("Starting executor for StatisticsWorker");
         executorService = Executors.newScheduledThreadPool(1, THREAD_FACTORY);
         executorService.scheduleAtFixedRate(this, 0, interval, TimeUnit.MILLISECONDS);
-        logger.info("StatisticsWorker executor started");
+        LOGGER.info("StatisticsWorker executor started");
     }
 
     public void stop() {
@@ -104,28 +103,37 @@ public class StatisticsWorker implements Runnable, EntityStatisticsCollector, Me
 
         // ensure that cache is empty before executor service initiating shutdown
         if (bookCounterCachesNotEmpty()) {
-            logger.info("Waiting statistics cache depletion");
+            LOGGER.info("Waiting statistics cache depletion");
             while (bookCounterCachesNotEmpty())
                 try {
                     Thread.sleep(100); // FIXME: find another way to wait the empty cache state
                 } catch (InterruptedException e) {
-                    logger.error("Interrupted while waiting statistics cache depletion");
+                    LOGGER.error("Interrupted while waiting statistics cache depletion");
                 }
         }
 
         // shut down executor service and wait for current job to complete
-        logger.info("Shutting down StatisticsWorker executor");
+        LOGGER.info("Shutting down StatisticsWorker executor");
         executorService.shutdown();
         try {
-            logger.debug("Waiting StatisticsWorker jobs to complete");
-            executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS); // FIXME: limit await timeout
-            logger.debug("StatisticsWorker shutdown complete");
+            LOGGER.debug("Waiting StatisticsWorker jobs to complete");
+            if (executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS)) {
+                LOGGER.info("StatisticsWorker shutdown complete");
+            } else {
+                int neverCommencedTasks = executorService.shutdownNow().size();
+                LOGGER.warn("StatisticsWorker executor service can't be stopped gracefully, " +
+                        "{} tasks will never be commenced", neverCommencedTasks);
+            }
         } catch (InterruptedException e) {
-            logger.error("Interrupted while waiting jobs to complete");
+            LOGGER.error("Interrupted while waiting jobs to complete", e);
         }
 
         // After executor service stops, we need to wait for futures to complete
-        futures.awaitRemaining();
+        try {
+            futures.awaitRemaining();
+        } catch (InterruptedException e) {
+            LOGGER.error("Interrupted while waiting tracked features to complete");
+        }
     }
 
     private BookStatisticsRecordsCaches getBookStatisticsRecordsCaches(BookId bookId) {
@@ -194,19 +202,21 @@ public class StatisticsWorker implements Runnable, EntityStatisticsCollector, Me
     }
 
 
-    private void persistEntityCounters(BookId bookId, BookStatisticsRecordsCaches.EntityKey key, FrameType frameType, Collection<TimeFrameRecord<Counter>> records) {
+    private void persistEntityCounters(BookId bookId, BookStatisticsRecordsCaches.EntityKey key, FrameType frameType, Collection<TimeFrameRecord<Counter>> records) throws InterruptedException {
 
-        logger.trace("Persisting {} entity counters for {}:{}:{}", records.size(), bookId, key, frameType);
+        LOGGER.trace("Persisting {} entity counters for {}:{}:{}", records.size(), bookId, key, frameType);
         final EntityStatisticsOperator op = operators.getEntityStatisticsOperator();
 
-        final Consumer<List<EntityStatisticsEntity>> persistor = (List<EntityStatisticsEntity> batch) -> {
+        final Updater<List<EntityStatisticsEntity>> persistor = (List<EntityStatisticsEntity> batch) -> {
 
-            logger.debug("Persisting batch of {} entity statistic records", batch.size());
+            LOGGER.debug("Persisting batch of {} entity statistic records", batch.size());
             CompletableFuture<AsyncResultSet> future = op.update(batch, batchWriteAttrs);
-            futures.track(future);
+            if(!futures.track(future)) {
+                LOGGER.warn("Update entity statistic feature isn't tracked");
+            }
             future.whenComplete((result, e) -> {
                 if (e != null) {
-                    logger.error("Exception persisting message counters, rescheduling", e);
+                    LOGGER.error("Exception persisting message counters, rescheduling", e);
                     TimeFrameRecordSamples<Counter> samples = getBookStatisticsRecordsCaches(bookId)
                                                                         .getEntityCounterCache()
                                                                         .get(key)
@@ -226,31 +236,33 @@ public class StatisticsWorker implements Runnable, EntityStatisticsCollector, Me
                                                     counter.getRecord().getEntityCount(),
                                                     counter.getRecord().getEntitySize()));
             if (batch.size() >= MAX_BATCH_STATEMENTS) {
-                persistor.accept(batch);
+                persistor.update(batch);
                 batch = new ArrayList<>();
             }
         }
 
         // persist any leftover batch
-        if (batch.size() > 0) {
-            persistor.accept(batch);
+        if (!batch.isEmpty()) {
+            persistor.update(batch);
         }
     }
 
 
-    private void persistMessageCounters(BookId bookId, BookStatisticsRecordsCaches.MessageKey key, FrameType frameType, Collection<TimeFrameRecord<Counter>> records) {
+    private void persistMessageCounters(BookId bookId, BookStatisticsRecordsCaches.MessageKey key, FrameType frameType, Collection<TimeFrameRecord<Counter>> records) throws InterruptedException {
 
-        logger.trace("Persisting {} message counters for {}:{}:{}:{}", records.size(), bookId, key.getSessionAlias(), key.getDirection(), frameType);
+        LOGGER.trace("Persisting {} message counters for {}:{}:{}:{}", records.size(), bookId, key.getSessionAlias(), key.getDirection(), frameType);
         final MessageStatisticsOperator op = operators.getMessageStatisticsOperator();
 
-        final Consumer<List<MessageStatisticsEntity>> persistor = (List<MessageStatisticsEntity> batch) -> {
+        final Updater<List<MessageStatisticsEntity>> persistor = (List<MessageStatisticsEntity> batch) -> {
 
-            logger.debug("Persisting batch of {} message statistic records", batch.size());
+            LOGGER.debug("Persisting batch of {} message statistic records", batch.size());
             CompletableFuture<AsyncResultSet> future = op.update(batch, batchWriteAttrs);
-            futures.track(future);
+            if(!futures.track(future)) {
+                LOGGER.warn("Update message statistic feature isn't tracked");
+            }
             future.whenComplete((result, e) -> {
                 if (e != null) {
-                    logger.error("Exception persisting message counters, rescheduling", e);
+                    LOGGER.error("Exception persisting message counters, rescheduling", e);
                     TimeFrameRecordSamples<Counter> samples = getBookStatisticsRecordsCaches(bookId)
                                                                         .getMessageCounterCache()
                                                                         .get(key)
@@ -271,21 +283,21 @@ public class StatisticsWorker implements Runnable, EntityStatisticsCollector, Me
                                                     counter.getRecord().getEntityCount(),
                                                     counter.getRecord().getEntitySize()));
             if (batch.size() >= MAX_BATCH_STATEMENTS) {
-                persistor.accept(batch);
+                persistor.update(batch);
                 batch = new ArrayList<>();
             }
         }
 
         // persist any leftover batch
-        if (batch.size() > 0) {
-            persistor.accept(batch);
+        if (!batch.isEmpty()) {
+            persistor.update(batch);
         }
     }
 
 
-    private void persistSessionStatistics(BookId bookId, BookStatisticsRecordsCaches.SessionRecordKey key, FrameType frameType, Collection<TimeFrameRecord<SessionList>> records) {
+    private void persistSessionStatistics(BookId bookId, BookStatisticsRecordsCaches.SessionRecordKey key, FrameType frameType, Collection<TimeFrameRecord<SessionList>> records) throws InterruptedException {
 
-        logger.trace("Persisting session statistics for {}:{}:{}:{} with {} records"
+        LOGGER.trace("Persisting session statistics for {}:{}:{}:{} with {} records"
                                                                                     , bookId
                                                                                     , key.getPage()
                                                                                     , key.getRecordType()
@@ -295,14 +307,16 @@ public class StatisticsWorker implements Runnable, EntityStatisticsCollector, Me
         final SessionStatisticsOperator op = operators.getSessionStatisticsOperator();
         final LimitedCache<SessionStatisticsEntity> cache = operators.getSessionStatisticsCache();
 
-        final Consumer<List<SessionStatisticsEntity>> persistor = (List<SessionStatisticsEntity> batch) -> {
+        final Updater<List<SessionStatisticsEntity>> persistor = (List<SessionStatisticsEntity> batch) -> {
 
-            logger.debug("Persisting batch of {} session statistic records", batch.size());
+            LOGGER.debug("Persisting batch of {} session statistic records", batch.size());
             CompletableFuture<AsyncResultSet> future = op.write(batch, batchWriteAttrs);
-            futures.track(future);
+            if(!futures.track(future)) {
+                LOGGER.warn("Update session statistic feature isn't tracked");
+            }
             future.whenComplete((result, e) -> {
                 if (e != null) {
-                    logger.error("Exception persisting session statistics, rescheduling", e);
+                    LOGGER.error("Exception persisting session statistics, rescheduling", e);
                     TimeFrameRecordSamples<SessionList> samples = getBookStatisticsRecordsCaches(bookId)
                                                                             .getSessionRecordCache()
                                                                             .get(key)
@@ -325,22 +339,22 @@ public class StatisticsWorker implements Runnable, EntityStatisticsCollector, Me
                                                                                 sessionsRecord.getFrameStart(),
                                                                                 session);
                 if (!cache.contains(entity)) {
-                    logger.trace("Batching {}", entity);
+                    LOGGER.trace("Batching {}", entity);
                     batch.add(entity);
                 } else {
-                    logger.trace("{} found in cache, ignoring", entity);
+                    LOGGER.trace("{} found in cache, ignoring", entity);
                 }
 
                 if (batch.size() >= MAX_BATCH_STATEMENTS) {
-                    persistor.accept(batch);
+                    persistor.update(batch);
                     batch = new ArrayList<>();
                 }
             }
         }
 
         // persist any leftover batch
-        if (batch.size() > 0) {
-            persistor.accept(batch);
+        if (!batch.isEmpty()) {
+            persistor.update(batch);
         }
     }
 
@@ -349,9 +363,7 @@ public class StatisticsWorker implements Runnable, EntityStatisticsCollector, Me
     private <K extends BookStatisticsRecordsCaches.RecordKey, V> void processRecords(
             BookId bookId,
             BookStatisticsRecordsCaches.RecordCache<K, V> recordCache,
-            Persistor<K, V> persistor)
-
-    {
+            Persistor<K, V> persistor) throws InterruptedException {
         Collection<K> keys = recordCache.getKeys();
         for (K key : keys) {
             TimeFrameRecordCache<V> timeFrameRecords = recordCache.extract(key);
@@ -365,7 +377,7 @@ public class StatisticsWorker implements Runnable, EntityStatisticsCollector, Me
 
     @Override
     public void run() {
-        logger.trace("executing StatisticsWorker job");
+        LOGGER.trace("executing StatisticsWorker job");
 
         try {
             for (BookId bookId: bookCounterCaches.keySet()) {
@@ -382,14 +394,18 @@ public class StatisticsWorker implements Runnable, EntityStatisticsCollector, Me
                 processRecords(bookId, bookStatisticsRecordsCaches.getSessionRecordCache(), this::persistSessionStatistics);
             }
         } catch (Exception e) {
-            logger.error("Exception processing job", e);
+            LOGGER.error("Exception processing job", e);
         }
 
-        logger.trace("StatisticsWorker job complete");
+        LOGGER.trace("StatisticsWorker job complete");
     }
 
-
+    @FunctionalInterface
     private interface Persistor<K extends BookStatisticsRecordsCaches.RecordKey, V> {
-        void persist(BookId bookId, K key, FrameType frameType, Collection<TimeFrameRecord<V>> records);
+        void persist(BookId bookId, K key, FrameType frameType, Collection<TimeFrameRecord<V>> records) throws InterruptedException;
+    }
+
+    private interface Updater<T> {
+        void update(T data) throws InterruptedException;
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-release_version=5.4.4
+release_version=5.5.0
 description='Cradle API'
 vcs_url=https://github.com/th2-net/cradleapi

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ th2-plugin = "0.2.4"
 
 [libraries]
 th2-bom = { group = "com.exactpro.th2", name = "bom", version = "4.11.0" }
-task-utils = { group = "com.exactpro.th2", name = "task-utils", version = "0.1.3" }
+task-utils = { group = "com.exactpro.th2", name = "task-utils", version = "0.1.4-TH2-5286-14055433562-729bf91-SNAPSHOT" }
 caffeine = { group = "com.github.ben-manes.caffeine", name = "caffeine", version = "3.2.0" }
 simpleclient-dropwizard = { group = "io.prometheus", name = "simpleclient_dropwizard", version = "0.16.0" }
 assertj-core = { group = "org.assertj", name = "assertj-core", version = "3.27.3" }


### PR DESCRIPTION
  * Added `counterPersistenceMaxParallelQueries` option to configure how many queries can be executed in parallel for statistic persistence.
* Updated:
  * th2 gradle plugin: `0.2.4` (bom: `4.11.0`)
  * task-utils: `0.1.4`
  * caffeine: `3.2.0`